### PR TITLE
MATLAB 2022a

### DIFF
--- a/easyconfigs/a/alsa-lib/alsa-lib-1.2.7.2.eb
+++ b/easyconfigs/a/alsa-lib/alsa-lib-1.2.7.2.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'alsa-lib'
+version = '1.2.7.2'
+
+homepage = 'https://www.alsa-project.org'
+description = """The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality
+ to the Linux operating system."""
+
+toolchain = SYSTEM
+
+source_urls = ['ftp://ftp.alsa-project.org/pub/lib/']
+sources = [SOURCE_TAR_BZ2]
+checksums = ['8a35b7218e50f2a2c79342d0de98ded81439ce19e12809385ec9be9596de7c2f']
+
+sanity_check_paths = {
+    'files': ['bin/aserver', 'include/asoundlib.h', 'lib64/libatopology.so', 'lib64/libasound.so'],
+    'dirs': ['include/alsa', 'lib/pkgconfig', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easyconfigs/m/MATLAB/MATLAB-2022a.eb
+++ b/easyconfigs/m/MATLAB/MATLAB-2022a.eb
@@ -12,7 +12,6 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['3582e8fc0e0b8bc8284fb5f09876a7243b1422819af2ba7861bf1cacc643d1bc']
 
 dependencies = [
-    ('Java', '11'),
     ('alsa-lib', '1.2.7.2'),  # libasound.so.2 is needed for simulink
 ]
 

--- a/easyconfigs/m/MATLAB/MATLAB-2022a.eb
+++ b/easyconfigs/m/MATLAB/MATLAB-2022a.eb
@@ -1,0 +1,32 @@
+name = 'MATLAB'
+version = '2022a'
+
+homepage = 'https://www.mathworks.com/products/matlab'
+description = """MATLAB is a high-level language and interactive environment
+ that enables you to perform computationally intensive tasks faster than with
+ traditional programming languages such as C, C++, and Fortran."""
+
+toolchain = SYSTEM
+
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['3582e8fc0e0b8bc8284fb5f09876a7243b1422819af2ba7861bf1cacc643d1bc']
+
+dependencies = [
+    ('Java', '11'),
+    ('alsa-lib', '1.2.7.2'),  # libasound.so.2 is needed for simulink
+]
+
+java_options = '-Xmx2048m'
+
+# osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
+
+# Use EB_MATLAB_KEY environment variable or uncomment and modify license key
+# key = '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000'
+
+# Use EB_MATLAB_LICENSE_SERVER and EB_MATLAB_LICENSE_SERVER_PORT environment variables or
+# uncomment and modify the following variables for installation with floating license server
+# license_file = 'my-license-file'
+# license_server = 'my-license-server'
+# license_server_port = '1234'
+
+moduleclass = 'math'


### PR DESCRIPTION
For INC1271218 - `MATLAB-2022a.eb`

Requires: https://gitlab.bham.ac.uk/res-comp-team/bear-license-servers/-/merge_requests/8

N.B. the necessary env vars will need setting in order to perform the install

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell
