### PR TITLE
CIRI-long 1.1.0

### DIFF
--- a/easyconfigs/c/CIRI-long/CIRI-long-1.1.0-foss-2021b.eb
+++ b/easyconfigs/c/CIRI-long/CIRI-long-1.1.0-foss-2021b.eb
@@ -60,5 +60,4 @@ sanity_check_paths = {
 sanity_check_commands = [
     'CIRI-long --help',
 ]
-options = {'modulename': 'CIRI-long'}
 moduleclass = 'bio'

--- a/easyconfigs/c/CIRI-long/CIRI-long-1.1.0-foss-2021b.eb
+++ b/easyconfigs/c/CIRI-long/CIRI-long-1.1.0-foss-2021b.eb
@@ -1,0 +1,64 @@
+# This easyconfig was based on the work done by Kenneth Hoste for CIRI-long-1.0.2-foss-2020b.eb
+easyblock = 'PythonBundle'
+
+name = 'CIRI-long'
+version = '1.1.0'
+
+homepage = 'https://github.com/bioinfo-biols/CIRI-long/'
+description = "Circular RNA Identification for Long-Reads Nanopore Sequencing Data"
+citing = """Zhang, J., Hou, L., Zuo, Z., Ji, P., Zhang, X., Xue, Y., & Zhao, F. (2021).
+ Comprehensive profiling of circular RNAs with nanopore sequencing and CIRI-long. Nature Biotechnology.
+ https://doi.org/10.1038/s41587-021-00842-6"""
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+builddependencies = [
+    ('Rust', '1.56.0'),  # needed by maturin
+    ('CMake', '3.21.1'),
+]
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+    ('scikit-learn', '1.0.1'),
+    ('Pysam', '0.18.0'),
+    ('minimap2', '2.24'),  # matching mappy extension
+    ('SAMtools', '1.15.1'),
+    ('Biopython', '1.79'),
+    ('pyspoa', '0.0.8'),
+    ('python-Levenshtein', '0.12.2'),
+    ('edlib', '1.3.9'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+local_sc = 'pyccs-1.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl'
+
+exts_list = [
+    ('mappy', '2.24', {
+        'checksums': ['35a2fb73ef14173283d5abb31e7a318429e0330c3be95851df38dd83d4ff9af9'],
+    }),
+    ('bwapy', '0.1.4', {
+        'checksums': ['fcdad0c7311753d550b3a3aefbc2619380e7e35e7aeaa386fd491cba47e71824'],
+    }),
+    ('pyccs', version, {
+        'sources': [{'download_filename': local_sc, 'filename': local_sc}],
+        'checksums': ['b8bbbca2b2183380dbf012f3a84cd7cff2bd31199d1782c7532fb6429480c5bb'],
+    }),
+    ('CIRI_long', version, {
+        'modulename': 'CIRI_long',
+        'preinstallopts': "make lib && sed -i '/install_requires/,+4d' setup.py && ",
+        'source_urls': ['https://github.com/bioinfo-biols/CIRI-long/archive/'],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'checksums': ['6f8bc5071e4d724fc4b62164c6e8bede93818ed7b1266d3a7a6b32232bfbf839'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/CIRI-long'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+sanity_check_commands = [
+    'CIRI-long --help',
+]
+options = {'modulename': 'CIRI-long'}
+moduleclass = 'bio'

--- a/easyconfigs/p/pyspoa/pyspoa-0.0.8-GCC-11.2.0.eb
+++ b/easyconfigs/p/pyspoa/pyspoa-0.0.8-GCC-11.2.0.eb
@@ -1,0 +1,52 @@
+easyblock = 'PythonPackage'
+
+name = 'pyspoa'
+version = '0.0.8'
+
+homepage = 'https://github.com/nanoporetech/pyspoa'
+description = "Python bindings to spoa."
+
+toolchain = {'name': 'GCC', 'version': '11.2.0'}
+
+sources = [
+    {
+        'source_urls': ['https://github.com/nanoporetech/pyspoa/archive/'],
+        'download_filename': 'v%(version)s.tar.gz',
+        'filename': 'pyspoa-%(version)s.tar.gz',
+    },
+    {
+        'source_urls': ['https://github.com/USCiLab/cereal/archive/'],
+        'download_filename': '3e4d1b8.tar.gz',
+        'filename': 'cereal-20200423.tar.gz',
+    },
+]
+patches = ['pyspoa-%(version)s_use-spoa-dep.patch']
+checksums = [
+    'a1e630ef30a42d8e8c076d914261d0d34060631d64694569d52c1a2be5deada7',  # pyspoa-0.0.8.tar.gz
+    '284cd14c1e60b36c966bcc8ce650d0b798b8a836d6c379e021e0da0dbe6ddf38',  # cereal-20200423.tar.gz
+    'a98c82ae8346b48952b171675f9df7ab1c95ea5421afcf5bcd778c01c5ee5a52',  # pyspoa-0.0.8_use-spoa-dep.patch
+]
+
+builddependencies = [('CMake', '3.21.1')]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('pybind11', '2.7.1'),
+    ('spoa', '4.0.7'),
+]
+
+download_dep_fail = True
+
+preinstallopts = "mkdir -p src/vendor/cereal && ln -s %(builddir)s/cereal-*/include src/vendor/cereal/include && "
+# strip out cmake requirements, since we provide that as proper dependency
+preinstallopts += "sed -i 's/.cmake==[0-9.]*.//g' setup.py && "
+
+use_pip = True
+
+options = {'modulename': 'spoa'}
+
+sanity_pip_check = True
+
+sanity_check_commands = ["cd %(builddir)s/*/tests && python test_pyspoa.py"]
+
+moduleclass = 'lib'

--- a/easyconfigs/p/python-Levenshtein/python-Levenshtein-0.12.2-foss-2021b.eb
+++ b/easyconfigs/p/python-Levenshtein/python-Levenshtein-0.12.2-foss-2021b.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'python-Levenshtein'
+version = '0.12.2'
+
+homepage = 'https://pypi.org/project/python-Levenshtein/'
+description = 'Python extension for computing string edit distances and similarities.'
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['dc2395fbd148a1ab31090dd113c366695934b9e85fe5a4b2a032745efd0346f6']
+
+dependencies = [
+    ('Python', '3.9.6'),
+]
+
+download_dep_fail = True
+use_pip = True
+
+options = {'modulename': 'Levenshtein'}
+
+sanity_pip_check = True
+
+moduleclass = 'data'

--- a/easyconfigs/s/spoa/spoa-4.0.7-GCC-11.2.0.eb
+++ b/easyconfigs/s/spoa/spoa-4.0.7-GCC-11.2.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'CMakeMake'
+
+name = 'spoa'
+version = '4.0.7'
+
+homepage = 'https://github.com/rvaser/spoa'
+description = """Spoa (SIMD POA) is a c++ implementation of the partial order alignment (POA) algorithm
+ which is used to generate consensus sequences"""
+
+toolchain = {'name': 'GCC', 'version': '11.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/rvaser/spoa/releases/download/%(version)s/']
+sources = ['spoa-v%(version)s.tar.gz']
+checksums = ['f7a8cd039e4aabea1481e123387fedaa8f87e55418a3649408a615f5c6b1b9a4']
+
+builddependencies = [('CMake', '3.21.1')]
+
+configopts = "-Dspoa_build_executable=ON"
+
+sanity_check_paths = {
+    'files': ['bin/spoa'] + ['include/spoa/%s' % x for x in ['alignment_engine.hpp', 'graph.hpp', 'spoa.hpp']] +
+             ['lib/libspoa.a', 'lib/pkgconfig/spoa-1.pc'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["spoa --help"]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1267960- `CIRI-long-1.1.0-foss-2021b.eb`

Also requires:
`Pyspoa-0.0.8-GCC-11.2.0.eb` - pulled from upstream
`python-Levenshtein-0.12.2-foss-2021b.eb` - pulled from upstream and bumped to latest available release
`spoa-4.0.7-GCC-11.2.0.eb` - pulled from upstream

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

