### PR TITLE
maftools + add to BIO meta package 

### DIFF
--- a/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2021b-foss-2021b-R-4.2.0.eb
+++ b/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2021b-foss-2021b-R-4.2.0.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('celldex', '1.6.0', versionsuffix),
     ('clusterProfiler', '4.4.4', versionsuffix),
     ('ggfortify', '0.4.14', versionsuffix),
+    ('maftools', '2.12.0', versionsuffix),
 ]
 
 moduleclass = 'bio'

--- a/easyconfigs/m/maftools/maftools-2.12.0-foss-2021b-R-4.2.0.eb
+++ b/easyconfigs/m/maftools/maftools-2.12.0-foss-2021b-R-4.2.0.eb
@@ -1,0 +1,49 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'maftools'
+version = '2.12.0'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://bioconductor.org/packages/release/bioc/html/maftools.html"
+description = """Analyze and visualize Mutation Annotation Format (MAF) files from large scale sequencing studies.
+ This package provides various functions to perform most commonly used analyses in cancer genomics and to create
+ feature rich customizable visualzations with minimal effort."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('R', '4.2.0'),
+    ('R-bundle-Bioconductor', '3.15', '-R-%(rver)s'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://bioconductor.org/packages/3.15/bioc/src/contrib/',
+        'https://bioconductor.org/packages/3.15/bioc/src/contrib/Archive/%(name)s',
+        'https://bioconductor.org/packages/3.15/data/annotation/src/contrib/',
+        'https://bioconductor.org/packages/3.15/data/experiment/src/contrib/',
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# Order is important!
+exts_list = [
+    (name, version, {
+        'checksums': ['66ceeb909cc6bd3a952f305273f95a6ee836c5033252c58925463bb24b8a0ebf'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['maftools/R/maftools'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1312505- `maftools-2.12.0-foss-2021b-R-4.2.0.eb`

_INC1312505 is primarily concerned with usage of maftools within the CCB MSc RStudio (2022) environment_
_Shout at me if there's anything missing from this PR to get it working for the CCB_

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Delete this if not requested:
* [ ] Ubuntu20 VM
