### PR TITLE
build kseq_test trimmer

### DIFF
--- a/easyconfigs/k/kseq/kseq-20221202-GCCcore-11.2.0.eb
+++ b/easyconfigs/k/kseq/kseq-20221202-GCCcore-11.2.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'MakeCp'
+
+name = 'kseq'
+version = '20221202'
+local_commit = 'bbc9eec9265c'
+
+homepage = "https://bitbucket.org/qzhudfci/cutruntools"
+description = """This tool further trims the reads by 6 nt to get rid of the problem of
+ possible adapter run-through"""
+
+toolchain = SYSTEM
+
+source_urls = ['https://bitbucket.org/qzhudfci/cutruntools/get/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': '%(namelower)s-%(version)s.zip'}]
+checksums = ['794e4b48d0172439e4b98f5473e776ef731f2d5197165bb4f890505ae87fea35']
+
+build_cmd = "sh make_kseq_test.sh"
+
+files_to_copy = [(['kseq_test'], 'bin'), 'LICENSE.md', 'README.md', ]
+
+sanity_check_paths = {
+    'files': ['bin/kseq_test'],
+    'dirs': []
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1323374 - `kseq-20221202-GCCcore-11.2.0.eb`

There's some possibility that this might be needed for 2019b but the easyconfig should be directly portable.

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Delete this if not requested:
* [ ] Ubuntu20 VM
