### PR TITLE
OSU iimpi 2021b to match the other versions

### DIFF
--- a/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.7.1-iimpi-2021b.eb
+++ b/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.7.1-iimpi-2021b.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'OSU-Micro-Benchmarks'
+version = '5.7.1'
+
+homepage = 'https://mvapich.cse.ohio-state.edu/benchmarks/'
+description = """OSU Micro-Benchmarks"""
+
+toolchain = {'name': 'iimpi', 'version': '2021b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://mvapich.cse.ohio-state.edu/download/mvapich/']
+sources = [SOURCELOWER_TGZ]
+checksums = ['cb5ce4e2e68ed012d9952e96ef880a802058c87a1d840a2093b19bddc7faa165']
+
+local_benchmark_dirs = [
+    'libexec/osu-micro-benchmarks/mpi/%s' % x for x in ['collective', 'one-sided', 'pt2pt', 'startup']
+]
+modextrapaths = {'PATH': local_benchmark_dirs}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': local_benchmark_dirs,
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
For consistency - `OSU-Micro-Benchmarks-5.7.1-iimpi-2021b.eb`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

