### PR TITLE
CellRanger 7.1.0 (2022a)

### DIFF
--- a/easyconfigs/c/CellRanger/CellRanger-7.1.0.eb
+++ b/easyconfigs/c/CellRanger/CellRanger-7.1.0.eb
@@ -1,0 +1,33 @@
+# The STAR binary included in this version has been vectorized with AVX
+# hence it is not recommended for systems that do not support it.
+
+easyblock = 'Tarball'
+
+name = 'CellRanger'
+version = '7.1.0'
+
+homepage = 'https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger'
+description = """Cell Ranger is a set of analysis pipelines that process Chromium
+ single-cell RNA-seq output to align reads, generate gene-cell matrices and perform
+ clustering and gene expression analysis."""
+
+toolchain = SYSTEM
+
+download_instructions = """
+Download manually from https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest
+"""
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['5c4f9b142e3c30ad10ae15d25868df2b4fd05bdb3bbd47da0c83a7cc649b577e']
+
+keepsymlinks = True
+
+sanity_check_paths = {
+    'files': ['bin/cellranger'],
+    'dirs': ['bin/rna', 'bin/tenkit'],
+}
+
+# currently this var needs exporting to pass the system check
+sanity_check_commands = ['export MRO_DISK_SPACE_CHECK=disable && cellranger testrun --id=tiny']
+
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1371944 - `CellRanger-7.1.0.eb`

- Slight change from upstream as the sanity check currently requires `export MRO_DISK_SPACE_CHECK=disable` to avoid failing the available disk space check.

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell
