### PR TITLE
switch to mofapy2 0.6.7

### DIFF
--- a/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2021b-MSc-foss-2021b-R-4.2.0.eb
+++ b/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2021b-MSc-foss-2021b-R-4.2.0.eb
@@ -27,7 +27,7 @@ dependencies = [
     # ('faahKO', '1.36.0', versionsuffix),  # Bioc 3.16
     # ('pandaR', '1.28.0', versionsuffix),  # Bioc 3.16
     ('iRF', '3.0.0', versionsuffix),
-    ('mofapy2', '0.7.0'),
+    ('mofapy2', '0.6.7'),
     ('MOFA2', '1.8.0', versionsuffix),
     ('smotefamily', '1.3.1', versionsuffix),
 ]

--- a/easyconfigs/m/mofapy2/mofapy2-0.6.7-foss-2021b.eb
+++ b/easyconfigs/m/mofapy2/mofapy2-0.6.7-foss-2021b.eb
@@ -1,0 +1,35 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'mofapy2'
+version = '0.6.7'
+
+homepage = "https://biofam.github.io/MOFA2/"
+description = """MOFA is a factor analysis model that provides a general framework for the integration of multi-omic
+ data sets in an unsupervised fashion."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+    ('scikit-learn', '1.0.1'),
+    ('h5py', '3.6.0'),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_list = [
+    ('natsort', '8.2.0', {
+        'checksums': ['57f85b72c688b09e053cdac302dd5b5b53df5f73ae20b4874fcbffd8bf783d11'],
+    }),
+    ('anndata', '0.8.0', {
+        'checksums': ['94d2cc6f76c0317c0ac28564e3092b313b7ad19c737d66701961f3e620b9066e'],
+    }),
+    (name, version, {
+        'checksums': ['df084a59f15397886691fc0045032635914da118e73c76cec573e36ed930eb85'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easyconfigs/m/mofapy2/mofapy2-0.6.7-foss-2021b.eb
+++ b/easyconfigs/m/mofapy2/mofapy2-0.6.7-foss-2021b.eb
@@ -27,7 +27,11 @@ exts_list = [
     ('anndata', '0.8.0', {
         'checksums': ['94d2cc6f76c0317c0ac28564e3092b313b7ad19c737d66701961f3e620b9066e'],
     }),
+    ('argparse', '1.4.0', {
+        'checksums': ['62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4'],
+    }),
     (name, version, {
+        'preinstallopts': "touch description.md && ",
         'checksums': ['df084a59f15397886691fc0045032635914da118e73c76cec573e36ed930eb85'],
     }),
 ]


### PR DESCRIPTION
For INC1370279 - the associated MOFA2 requires an older mofapy2.

* [x] Assigned to reviewer

`mofapy2-0.6.7-foss-2021b.eb`:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

rebuild `BEAR-R-bio-2021b-MSc-foss-2021b-R-4.2.0.eb`:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

