### PR TITLE
initial BEAR R bio

### DIFF
--- a/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2022b-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2022b-foss-2022b-R-4.3.1.eb
@@ -1,0 +1,35 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'BEAR-R-bio'
+version = '2022b'
+versionsuffix = '-R-%(rver)s'
+
+homepage = ""
+description = """This module provides access to several R bio libraries."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('R', '4.3.1'),
+    ('R-bundle-Bioconductor', '3.17', versionsuffix),
+    # ('monocle', '2.24.1', versionsuffix),
+    # ('ottr', '1.2.0', versionsuffix),
+    # ('SpaTalk', '1.0', versionsuffix),
+    # ('celldex', '1.6.0', versionsuffix),
+    # ('ggfortify', '0.4.14', versionsuffix),
+    # ('maftools', '2.12.0', versionsuffix),
+    # ('nichenetr', '20220911', versionsuffix),
+    # ('cyCombine', '0.2.15', versionsuffix),
+    # ('msPurity', '1.22.0', versionsuffix),
+    # ('MSstats', '4.4.1', versionsuffix),
+    # ('faahKO', '1.36.0', versionsuffix),
+    # ('pandaR', '1.28.0', versionsuffix),
+    # ('iRF', '3.0.0', versionsuffix),
+    # ('mofapy2', '0.6.7'),
+    # ('MOFA2', '1.8.0', versionsuffix),
+    # ('smotefamily', '1.3.1', versionsuffix),
+    # ('phateR', '1.0.7', versionsuffix),
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1396312 - `BEAR-R-bio-2022b-foss-2022b-R-4.3.1.eb`

This is so we can add it to the Portal. Sorting out the extra easyconfigs for the MSc will happen in #211, hence the commented out older versions in here.

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

