### PR TITLE
mne-connectivity rebuild

### DIFF
--- a/easyconfigs/m/mne-connectivity/mne-connectivity-0.5.0-foss-2021b.eb
+++ b/easyconfigs/m/mne-connectivity/mne-connectivity-0.5.0-foss-2021b.eb
@@ -18,11 +18,11 @@ dependencies = [
     ('xarray', '0.20.1'),
     ('matplotlib', '3.4.3'),  # used for docs
     ('scikit-learn', '1.0.1'),  # used for extras
-    ('tqdm', '4.62.3'),  # used for extras
-    ('netcdf4-python', '1.5.7'),
+    ('tqdm', '4.62.3'),
     ('h5netcdf', '1.1.0'),  # upstream
     ('QtPy', '2.2.1'),
     ('PyQt5', '5.15.4'),  # for extras
+    ('netCDF', '4.8.1'),
 ]
 
 sanity_pip_check = True
@@ -32,9 +32,12 @@ exts_default_options = {
     'source_urls': [PYPI_SOURCE],
 }
 
+# newer version of netcdf4-python appears to fix module order load issues
+
 exts_list = [
-    ('pyvistaqt', '0.11.0', {
-        'checksums': ['8784e8ced4faacfe010524b20dd5675f81f25f1b1d6fb6442ba70437cbb6b1ef'],
+    ('netCDF4', '1.6.5', {
+        'modulename': 'netCDF4',
+        'checksums': ['824881d0aacfde5bd982d6adedd8574259c85553781e7b83e0ce82b890bfa0ef'],
     }),
     (name, version, {
         'checksums': ['7cbdaf0d4ac59fab4fc193f52125995b2f930701f153cf9dcb740d414667c6e8'],


### PR DESCRIPTION
For INC1427684 - `mne-connectivity-0.5.0-foss-2021b.eb`

* Uses newer version of netcdf-python - supplied as an extension + supporting dep.

`time eb mne-connectivity-0.5.0-foss-2021b.eb --rebuild --force -Tr`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

