### PR TITLE
Meep 1.28.0

### DIFF
--- a/easyconfigs/g/Guile/Guile-3.0.9-GCCcore-12.2.0.eb
+++ b/easyconfigs/g/Guile/Guile-3.0.9-GCCcore-12.2.0.eb
@@ -1,0 +1,46 @@
+easyblock = 'ConfigureMake'
+
+name = 'Guile'
+version = '3.0.9'
+
+homepage = 'https://www.gnu.org/software/guile/'
+
+description = """
+ Guile is a programming language, designed to help programmers create flexible
+ applications that can be extended by users or other programmers with plug-ins,
+ modules, or scripts.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['18525079ad29a0d46d15c76581b5d91c8702301bfd821666d2e1d13726162811']
+
+builddependencies = [
+    ('Autotools', '20220317'),
+    ('binutils', '2.39'),
+    ('pkgconf', '1.9.3'),
+]
+
+dependencies = [
+    ('gc', '8.2.4'),
+    ('GMP', '6.2.1'),
+    ('libffi', '3.4.4'),
+    ('libunistring', '1.1'),
+]
+
+postinstallcmds = ["cd %(installdir)s/bin && ln -s guile guile%(version_major)s"]
+
+sanity_check_paths = {
+    'files': ['bin/guild', 'bin/guile', 'bin/guile-config',
+              'bin/guile-snarf', 'bin/guile-tools',
+              'include/guile/%(version_major_minor)s/libguile.h',
+              'lib/libguile-%(version_major_minor)s.a',
+              'lib/libguile-%%(version_major_minor)s.%s' % SHLIB_EXT],
+    'dirs': ['include/guile/%(version_major_minor)s/libguile',
+             'lib/guile/%(version_major_minor)s/ccache'],
+}
+
+moduleclass = 'lang'

--- a/easyconfigs/g/gc/gc-8.2.4-GCCcore-12.2.0.eb
+++ b/easyconfigs/g/gc/gc-8.2.4-GCCcore-12.2.0.eb
@@ -1,0 +1,42 @@
+easyblock = 'ConfigureMake'
+
+name = 'gc'
+version = '8.2.4'
+local_libatomic_version = '7.8.0'
+
+homepage = 'https://hboehm.info/gc/'
+description = """The Boehm-Demers-Weiser conservative garbage collector can be used as a
+garbage collecting replacement for C malloc or C++ new.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = [
+    'https://github.com/ivmai/bdwgc/releases/download/v%(version)s/',  # preferred for gc-%(version)s.tar.gz
+    'https://hboehm.info/gc/gc_source/',  # alternate for gc-%(version)s.tar.gz
+    'https://github.com/ivmai/libatomic_ops/releases/download/v%s/' % local_libatomic_version,
+]
+sources = [
+    SOURCE_TAR_GZ,
+    'libatomic_ops-%s.tar.gz' % local_libatomic_version,
+]
+checksums = [
+    '3d0d3cdbe077403d3106bb40f0cbb563413d6efdbb2a7e1cd6886595dec48fc2',  # gc-8.2.4.tar.gz
+    '15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31',  # libatomic_ops-7.8.0.tar.gz
+]
+
+builddependencies = [
+    ('binutils', '2.39'),
+]
+
+preconfigopts = 'ln -s %(builddir)s/libatomic_ops*/ libatomic_ops && '
+
+configopts = "--enable-static"
+
+sanity_check_paths = {
+    'files': ['include/gc.h', 'lib/libcord.a', 'lib/libcord.%s' % SHLIB_EXT,
+              'lib/libgc.a', 'lib/libgc.%s' % SHLIB_EXT],
+    'dirs': ['include/gc', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easyconfigs/h/Harminv/Harminv-1.4.2-foss-2022b.eb
+++ b/easyconfigs/h/Harminv/Harminv-1.4.2-foss-2022b.eb
@@ -1,0 +1,31 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'ConfigureMake'
+
+name = 'Harminv'
+version = '1.4.2'
+
+homepage = 'https://github.com/stevengj/harminv'
+description = """Harminv is a free program (and accompanying library) to solve the problem of harmonic inversion -
+ given a discrete-time, finite-length signal that consists of a sum of finitely-many sinusoids (possibly exponentially
+ decaying) in a given bandwidth, it determines the frequencies, decay constants, amplitudes, and phases of those
+ sinusoids."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+toolchainopts = {'opt': True, 'unroll': True, 'pic': True, 'cstd': 'c99'}
+
+source_urls = ['https://github.com/stevengj/%(namelower)s/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['5a9a1bf710972442f065d0d62c62d0c4ec3da4a3696d7160a35602c9470bc7a2']
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+
+configopts = '--with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" --enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib/libharminv.a', 'lib/libharminv.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'math'

--- a/easyconfigs/l/libGDSII/libGDSII-0.21-GCCcore-12.2.0.eb
+++ b/easyconfigs/l/libGDSII/libGDSII-0.21-GCCcore-12.2.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'libGDSII'
+version = '0.21'
+
+homepage = 'https://github.com/HomerReid/libGDSII'
+description = """libGDSII is a C++ library for working with GDSII binary data files,
+ intended primarily for use with the computational electromagnetism codes
+ scuff-em and meep but sufficiently general-purpose to allow other uses as well."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://github.com/HomerReid/libGDSII/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('binutils', '2.39'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/GDSIIConvert', 'include/libGDSII.h', 'lib/libGDSII.a', 'lib/libGDSII.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easyconfigs/l/libctl/libctl-4.5.1-GCCcore-12.2.0.eb
+++ b/easyconfigs/l/libctl/libctl-4.5.1-GCCcore-12.2.0.eb
@@ -1,0 +1,33 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'ConfigureMake'
+
+name = 'libctl'
+version = '4.5.1'
+
+homepage = 'https://libctl.readthedocs.io/en/latest/'  # 4.5.1 still the latest
+description = "libctl is a free Guile-based library implementing flexible control files for scientific simulations."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/NanoComp/%(name)s/releases/download/v%(version)s/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['fcfeb2f13dda05b560f0ec6872757d9318fdfe8f4bc587eb2053a29ba328ae25']
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('Autotools', '20220317'),  # required for libtool
+]
+dependencies = [
+    ('Guile', '3.0.9'),
+]
+
+configopts = "--with-pic --enable-shared"
+
+
+sanity_check_paths = {
+    'files': ['bin/gen-ctl-io', 'lib/%(name)s.a', 'lib/libctlgeom.a', 'lib/libctlgeom.so', 'lib/%(name)s.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'

--- a/easyconfigs/l/libunistring/libunistring-1.1-GCCcore-12.2.0.eb
+++ b/easyconfigs/l/libunistring/libunistring-1.1-GCCcore-12.2.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'libunistring'
+version = '1.1'
+
+homepage = 'https://www.gnu.org/software/libunistring/'
+
+description = """This library provides functions for manipulating Unicode strings and for
+ manipulating C strings according to the Unicode standard."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['827c1eb9cb6e7c738b171745dac0888aa58c5924df2e59239318383de0729b98']
+
+builddependencies = [
+    ('binutils', '2.39'),
+]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['lib/libunistring.a', 'lib/libunistring.%s' % SHLIB_EXT] +
+             ['include/uni%s.h' % x for x in ['case', 'conv', 'ctype', 'lbrk', 'name', 'norm',
+                                              'stdio', 'str', 'types', 'wbrk', 'width']],
+    'dirs': ['include/unistring'],
+}
+
+moduleclass = 'lib'

--- a/easyconfigs/m/MPB/MPB-1.11.1-foss-2022b.eb
+++ b/easyconfigs/m/MPB/MPB-1.11.1-foss-2022b.eb
@@ -1,0 +1,52 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'ConfigureMake'
+
+name = 'MPB'
+version = '1.11.1'
+
+homepage = 'https://mpb.readthedocs.io/en/latest/'
+description = """MPB is a free and open-source software package for computing
+ the band structures, or dispersion relations, and electromagnetic
+ modes of periodic dielectric structures, on both serial
+ and parallel computers. MPB is an acronym for MIT Photonic Bands."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['https://github.com/NanoComp/%(namelower)s/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['dc55b081c56079727dac92d309f8e4ea84ca6eea9122ec24b7955f8c258608e1']
+
+builddependencies = [
+    ('Autotools', '20220317'),
+]
+dependencies = [
+    ('Python', '3.10.8'),
+    ('HDF5', '1.14.0'),
+    ('libctl', '4.5.1'),
+    ('Guile', '3.0.9'),
+    ('libreadline', '8.2'),
+]
+
+configopts = [
+    '--with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" --with-libctl=$EBROOTLIBCTL/share/libctl \
+        --enable-shared  ',
+    '--with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" --with-libctl=$EBROOTLIBCTL/share/libctl \
+        --enable-shared  --with-inv-symmetry',
+    '--with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" --with-libctl=$EBROOTLIBCTL/share/libctl \
+        --enable-shared  --with-mpi ',
+    '--with-pic --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" --with-libctl=$EBROOTLIBCTL/share/libctl \
+        --enable-shared  --with-mpi --with-inv-symmetry',
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'bin/%(namelower)s-data',
+              'bin/mpbi', 'bin/mpbi-data', 'bin/mpbi-mpi', 'bin/mpbi-split',
+              'bin/%(namelower)s-mpi', 'bin/%(namelower)s-split', 'lib/libmpb.a',
+              'lib/libmpbi_mpi.a', 'lib/libmpbi.a', 'lib/libmpb_mpi.a', 'lib/libmpb.so',
+              'lib/libmpbi_mpi.so', 'lib/libmpbi.so', 'lib/libmpb_mpi.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'phys'

--- a/easyconfigs/m/Meep/Meep-1.28.0-foss-2022b.eb
+++ b/easyconfigs/m/Meep/Meep-1.28.0-foss-2022b.eb
@@ -1,0 +1,50 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'ConfigureMake'
+
+name = 'Meep'
+version = '1.28.0'
+
+homepage = 'https://meep.readthedocs.io'
+description = """Meep is a free and open-source software package for electromagnetics simulation via
+ the finite-difference time-domain (FDTD) method spanning a broad range of applications."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+toolchainopts = {'usempi': True, 'opt': True, 'optarch': True, 'unroll': True, 'pic': True}
+
+source_urls = ['https://github.com/NanoComp/%(namelower)s/releases/download/v%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['1b9d603c94a55e5fb8370862060a302b267fb342b0fdaf12da8e11b36a122aa5']
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+    ('SWIG', '4.1.1'),
+]
+
+# autograd no longer required
+dependencies = [
+    ('Python', '3.10.8'),
+    ('SciPy-bundle', '2023.02'),
+    ('matplotlib', '3.7.0'),
+    ('HDF5', '1.14.0'),
+    ('Guile', '3.0.9'),
+    ('libctl', '4.5.1'),  # 4.5.1 still newest version
+    ('Harminv', '1.4.2'),
+    ('GSL', '2.7'),
+    ('MPB', '1.11.1'),  # 1.11.1 still newest version
+    ('libGDSII', '0.21'),  # 0.21 still newest version
+]
+
+configopts = '--with-pic --with-mpi --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" --without-gcc-arch '
+configopts += '--with-libctl=${EBROOTLIBCTL}/share/libctl '
+configopts += '--enable-shared GUILE_CONFIG="$EBROOTGUILE/bin/guile -e main -s $EBROOTGUILE/bin/guile-config"'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib/libmeep.so'],
+    'dirs': ['include', 'lib/python%(pyshortver)s/site-packages/%(namelower)s'],
+}
+
+sanity_check_commands = ["python -c 'import %(namelower)s'"]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+moduleclass = 'phys'


### PR DESCRIPTION
For IINC1439792 - `Meep-1.28.0-foss-2022b.eb`

**Deps:**

- `Guile-3.0.9-GCCcore-12.2.0.eb` - no upstream version for 2022b. Used same version as 2023a.
  - `libunistring-1.1-GCCcore-12.2.0.eb` - Guile dependency. No upstream version for 2022b.
  - `gc-8.2.4-GCCcore-12.2.0.eb` - Guile dependency. No upstream version for 2022b.
- `libctl-4.5.1-GCCcore-12.2.0.eb` - bumped our 2021b version. Still 4.5.1 still newest release.
- `Harminv-1.4.2-foss-2022b.eb` - installing newer point release
- `MPB-1.11.1-foss-2022b.eb` - bumped our 2021b version. 1.11.1 still newest release
- `libGDSII-0.21-GCCcore-12.2.0.eb` - bumped our 2021b version. 0.21 still newest release

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

