### PR TITLE
Autograd 1.6.3 +meep 1.28.0 rebuild

### DIFF
--- a/easyconfigs/a/autograd/autograd-1.6.3-foss-2022b.eb
+++ b/easyconfigs/a/autograd/autograd-1.6.3-foss-2022b.eb
@@ -1,0 +1,48 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'autograd'
+version = '1.6.3'
+_hash = '9a90bd6'
+github_account = 'HIPS'
+
+homepage = 'https://github.com/HIPS/autograd'
+description = """Autograd can automatically differentiate native Python and Numpy code. It can handle
+ a large subset of Python's features, including loops, ifs, recursion and closures, and it can even
+ take derivatives of derivatives of derivatives. It supports reverse-mode differentiation
+ (a.k.a. backpropagation), which means it can efficiently take gradients of scalar-valued functions
+ with respect to array-valued arguments, as well as forward-mode differentiation, and the two can be
+ composed arbitrarily. The main intended application of Autograd is gradient-based optimization."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('SciPy-bundle', '2023.02'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    (name, version, {
+        'source_urls': ['https://github.com/%(github_account)s/%(name)s/archive'],
+        'sources': [{'download_filename': '9a90bd6.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
+        'checksums': ['03f6330b6a93aaad536d28a8d35289bb1da53b070587aa3b2bf243dfad297358'],
+    }),
+]
+
+local_autograd_files = ['builtins.py', 'core.py', 'differential_operators.py', 'extend.py', 'test_util.py',
+                        'tracer.py', 'util.py', 'wrap_util.py']
+local_autograd_dirs = ['misc', 'numpy', 'scipy']
+
+sanity_check_paths = {
+    'files': ['lib/python%%(pyshortver)s/site-packages/%%(name)s/%s' % x for x in local_autograd_files],
+    'dirs': ['lib/python%%(pyshortver)s/site-packages/%%(name)s/%s' % x for x in local_autograd_dirs],
+}
+
+moduleclass = 'math'

--- a/easyconfigs/m/Meep/Meep-1.28.0-foss-2022b.eb
+++ b/easyconfigs/m/Meep/Meep-1.28.0-foss-2022b.eb
@@ -25,6 +25,7 @@ dependencies = [
     ('Python', '3.10.8'),
     ('SciPy-bundle', '2023.02'),
     ('matplotlib', '3.7.0'),
+    ('autograd', '1.6.3'),  # Meep no longer requires autograd but users might
     ('HDF5', '1.14.0'),
     ('Guile', '3.0.9'),
     ('libctl', '4.5.1'),  # 4.5.1 still newest version


### PR DESCRIPTION
For INC1439792

**Autograd:** - 1.6.3 dep requested by user (not required by Meep)
`eb autograd-1.6.3-foss-2022b.eb -Tr`

**Meep:** - rebuild 1.28.0 with the Autograd dep specified
`eb Meep-1.28.0-foss-2022b.eb --rebuild --force -Tr`

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Delete this if not requested:
* [ ] Ubuntu20 VM
