### PR TITLE
NLopt python bindings

### DIFF
--- a/easyconfigs/n/NLopt/NLopt-2.7.1-foss-2022b-Python.eb
+++ b/easyconfigs/n/NLopt/NLopt-2.7.1-foss-2022b-Python.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'NLopt'
+version = '2.7.1'
+versionsuffix = '-Python'
+
+homepage = 'http://ab-initio.mit.edu/wiki/index.php/NLopt'
+description = """ NLopt is a free/open-source library for nonlinear optimization,
+ providing a common interface for a number of different free optimization routines
+ available online as well as original implementations of various other algorithms. """
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/stevengj/nlopt/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['db88232fa5cef0ff6e39943fc63ab6074208831dc0031cf1545f6ecd31ae2a1a']
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+    ('binutils', '2.39'),
+]
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('SciPy-bundle', '2023.02'),
+    ('SWIG', '4.1.1'),
+    ('Guile', '3.0.9'),
+]
+
+configopts = [
+    '-DBUILD_SHARED_LIBS=ON',
+    '-DBUILD_SHARED_LIBS=OFF',
+]
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['lib/libnlopt.a', 'lib/libnlopt.%s' % SHLIB_EXT, 'include/nlopt.h'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+sanity_check_commands = ['python -c "import %(namelower)s"']
+
+moduleclass = 'numlib'


### PR DESCRIPTION
For INC1439792 - `NLopt-2.7.1-foss-2022b-Python.eb`

We need NLopt's Python Bindings. Like previous installs of this, i've done this in a separate easyconfig.

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell
