### PR TITLE
BAT, hypervolume, phytools R pkgs for 2022b 

### DIFF
--- a/easyconfigs/b/BAT/BAT-2.9.5-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/b/BAT/BAT-2.9.5-foss-2022b-R-4.3.1.eb
@@ -1,0 +1,51 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'BAT'
+version = '2.9.5'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://cran.r-project.org/package=BAT"
+description = """Includes algorithms to assess alpha and beta diversity in all their dimensions
+ (taxonomic, phylogenetic and functional). It allows performing a number of analyses based on species
+ identities/abundances, phylogenetic/functional distances, trees, convex-hulls or kernel density
+ n-dimensional hypervolumes depicting species relationships."""
+citing = """Cardoso et al. (2015) <doi:10.1111/2041-210X.12310>"""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('R', '4.3.1'),
+    ('hypervolume', '3.1.3', versionsuffix),
+    ('phytools', '2.0-3', versionsuffix),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# Order is important!
+exts_list = [
+    ('nls2', '0.3-3', {
+        'checksums': ['74d2fa178320823b98ddb72118d968ab9852f82123ae7183bb3289775dc7b116'],
+    }),
+    (name, version, {
+        'checksums': ['50b4181aaec28711edef56babdaf6a52b86f46a9817872d1053a0603409ae091'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['BAT/R/BAT'],
+    'dirs': [],
+}
+
+moduleclass = 'geo'

--- a/easyconfigs/h/hypvervolume/hypervolume-3.1.3-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/h/hypvervolume/hypervolume-3.1.3-foss-2022b-R-4.3.1.eb
@@ -1,0 +1,58 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'hypervolume'
+version = '3.1.3'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://cran.r-project.org/package=hypervolume"
+description = """Estimates the shape and volume of high-dimensional datasets and performs set operations:
+ intersection / overlap, union, unique components, inclusion test, and hole detection. Uses stochastic geometry
+ approach to high-dimensional kernel density estimation, support vector machine delineation, and convex hull
+ generation. Applications include modeling trait and niche hypervolumes and species distribution modeling."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('R', '4.3.1'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+
+# Order is important!
+exts_list = [
+    ('pdist', '1.2.1', {
+        'checksums': ['06904ee8c609cebd62553b5593c5d4e08abd3ed95b9f96c64e47c380a2466f2f'],
+    }),
+    ('rcdd', '1.6', {
+        'checksums': ['9f8acd8cad398369e93067196baa26d2d3109ce8d34daa1436f7bed42473db75'],
+    }),
+    ('hitandrun', '0.5-6', {
+        'checksums': ['8f651c6f1935cd36cf3ca160ddd8c06e452abefec3e67a6cc063475859f51164'],
+    }),
+    ('palmerpenguins', '0.1.1', {
+        'checksums': ['2a40d48ba6c7978fdf2a6daf647ccb39cd17590680138931d11194d3dd1a30b4'],
+    }),
+    (name, version, {
+        'checksums': ['2d0a1c0e4709cc4b4758fcf8cd0965226b941eafe4d152c4eaa512c283fba50f'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['hypervolume/R/hypervolume'],
+    'dirs': [],
+}
+
+moduleclass = 'geo'

--- a/easyconfigs/p/phytools/phytools-2.0-3-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/p/phytools/phytools-2.0-3-foss-2022b-R-4.3.1.eb
@@ -1,0 +1,45 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'phytools'
+version = '2.0-3'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://cran.r-project.org/package=phytools"
+description = """A wide range of methods for phylogenetic analysis - concentrated in phylogenetic comparative biology,
+ but also including numerous techniques for visualizing, analyzing, manipulating, reading or writing, and even inferring
+ phylogenetic trees."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('R', '4.3.1'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+
+# Order is important!
+exts_list = [
+    (name, version, {
+        'checksums': ['a10f5ceba81d5f8dc8e1b80e4cd00c7878842ee312ecd266809f60f70b23e82e'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['phytools/R/phytools'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1450176 - we won't build Picante yet as the latest version hasn't been published to CRAN.

Please build in this order:

- `hypervolume-3.1.3-foss-2022b-R-4.3.1.eb`
- `phytools-2.0-3-foss-2022b-R-4.3.1.eb`
- `BAT-2.9.5-foss-2022b-R-4.3.1.eb `

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
