### PR TITLE
remove cuDNN dep from wheel version of PyTorch

### DIFF
--- a/easyconfigs/p/PyTorch/PyTorch-2.0.1-foss-2022a-CUDA-11.7.0.eb
+++ b/easyconfigs/p/PyTorch/PyTorch-2.0.1-foss-2022a-CUDA-11.7.0.eb
@@ -27,7 +27,7 @@ dependencies = [
     ('expecttest', '0.1.3'),
     ('sympy', '1.11.1'),
     ('networkx', '2.8.4'),
-    ('cuDNN', '8.4.1.50', '-CUDA-%(cudaver)s', SYSTEM),
+    # ('cuDNN', '8.4.1.50', '-CUDA-%(cudaver)s', SYSTEM),  # PyTorch wheel contains a different cuDNN version
     ('magma', '2.6.2', '-CUDA-%(cudaver)s'),
     ('NCCL', '2.12.12', '-CUDA-%(cudaver)s'),
 ]


### PR DESCRIPTION
For INC1462866 - this change has already been deployed.