### PR TITLE
MATLAB R2023 Update 6

### DIFF
--- a/easyconfigs/m/MATLAB/MATLAB-2023b-r6.eb
+++ b/easyconfigs/m/MATLAB/MATLAB-2023b-r6.eb
@@ -1,0 +1,29 @@
+name = 'MATLAB'
+version = '2023b'
+_update = '6'
+versionsuffix = '-r%s' % _update
+
+homepage = 'https://www.mathworks.com/products/matlab'
+description = """MATLAB is a high-level language and interactive environment
+ that enables you to perform computationally intensive tasks faster than with
+ traditional programming languages such as C, C++, and Fortran."""
+
+toolchain = SYSTEM
+
+sources = ['R%s_Update_%s_Linux.iso' % (version, _update)]
+checksums = ['dc2d8d3fde322a6a806eba3ee32522c075c251b9bdf5c3b3e49cd5e7c6807293']
+download_instructions = 'Download %s from mathworks.com' % sources[0]
+
+java_options = '-Xmx2048m'
+
+osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
+
+# Use EB_MATLAB_KEY environment variable or uncomment and modify license key
+# key = '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000'
+
+# Use EB_MATLAB_LICENSE_SERVER and EB_MATLAB_LICENSE_SERVER_PORT environment variables or
+# uncomment and modify the following variables for installation with floating license server
+# license_file = 'my-license-file'
+# license_server_port = 'XXXXX'
+
+moduleclass = 'math'


### PR DESCRIPTION
For INC1466080 - `MATLAB-2023b-r6.eb`

- Modified from upstream to install "Update 6" of R2023b.

Pass to @orbsmiv to install as he has the keys.

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
