### PR TITLE
Cufflinks easyconf

### DIFF
--- a/easyconfigs/a/APR-util/APR-util-1.6.3-GCCcore-12.2.0.eb
+++ b/easyconfigs/a/APR-util/APR-util-1.6.3-GCCcore-12.2.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'APR-util'
+version = '1.6.3'
+
+homepage = 'https://apr.apache.org/'
+description = "Apache Portable Runtime (APR) util libraries."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://archive.apache.org/dist/apr/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['2b74d8932703826862ca305b094eef2983c27b39d5c9414442e9976a9acf1983']
+
+builddependencies = [('binutils', '2.39')]
+
+dependencies = [
+    ('APR', '1.7.4'),
+    ('SQLite', '3.39.4'),
+    ('expat', '2.4.9'),
+]
+
+configopts = "--with-apr=$EBROOTAPR/bin/apr-1-config --with-sqlite3=$EBROOTSQLITE --with-expat=$EBROOTEXPAT "
+
+sanity_check_paths = {
+    'files': ["bin/apu-1-config", "lib/libaprutil-1.%s" % SHLIB_EXT, "lib/libaprutil-1.a"],
+    'dirs': ["include/apr-1"],
+}
+
+parallel = 1
+
+moduleclass = 'tools'

--- a/easyconfigs/a/APR/APR-1.7.4-GCCcore-12.2.0.eb
+++ b/easyconfigs/a/APR/APR-1.7.4-GCCcore-12.2.0.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'APR'
+version = '1.7.4'
+
+homepage = 'https://apr.apache.org/'
+description = "Apache Portable Runtime (APR) libraries."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://archive.apache.org/dist/apr/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a4137dd82a185076fa50ba54232d920a17c6469c30b0876569e1c2a05ff311d9']
+
+builddependencies = [('binutils', '2.39')]
+
+sanity_check_paths = {
+    'files': ["bin/apr-1-config", "lib/libapr-1.%s" % SHLIB_EXT, "lib/libapr-1.a"],
+    'dirs': ["include/apr-1"],
+}
+
+moduleclass = 'tools'

--- a/easyconfigs/b/Boost/Boost-1.75.0-GCC-12.2.0.eb
+++ b/easyconfigs/b/Boost/Boost-1.75.0-GCC-12.2.0.eb
@@ -1,0 +1,28 @@
+name = 'Boost'
+version = '1.75.0'
+
+homepage = 'https://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+checksums = ['aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a']
+
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.2.12'),
+    ('XZ', '5.2.7'),
+    ('zstd', '1.5.2'),
+    ('ICU', '72.1'),
+]
+
+configopts = '--without-libraries=python,mpi'
+
+# disable MPI, build Boost libraries with tagged layout
+boost_mpi = False
+tagged_layout = True
+
+moduleclass = 'devel'

--- a/easyconfigs/c/Cufflinks/Cufflinks-20190706-AM_INIT_AUTOMAKE.patch
+++ b/easyconfigs/c/Cufflinks/Cufflinks-20190706-AM_INIT_AUTOMAKE.patch
@@ -1,0 +1,10 @@
+--- configure.ac.orig	2024-02-19 18:06:06.318530062 +0000
++++ configure.ac	2024-02-19 18:06:20.366602296 +0000
+@@ -14,7 +14,6 @@
+ AC_CONFIG_SRCDIR([config.h.in])
+ AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_AUX_DIR([build-aux])
+-AM_INIT_AUTOMAKE
+ 
+ #AM_PATH_CPPUNIT(1.10.2)
+ 

--- a/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-12.2.0.eb
+++ b/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-12.2.0.eb
@@ -8,7 +8,7 @@ homepage = 'http://cole-trapnell-lab.github.io/%(namelower)s/'
 description = "Transcript assembly, differential expression, and differential regulation for RNA-Seq"
 
 toolchain = {'name': 'GCC', 'version': '12.2.0'}
-toolchainopts = {'pic': True, 'cstd': 'c++17'}
+toolchainopts = {'pic': True, 'cstd': 'c++03'}
 
 github_account = 'cole-trapnell-lab'
 source_urls = [GITHUB_LOWER_SOURCE]
@@ -24,7 +24,9 @@ builddependencies = [
     ('Autotools', '20220317'),
     ('SAMtools', '1.17'),
     ('Subversion', '1.14.3'),
-    ('Boost', '1.81.0'),
+    # Boost <= 1.75.0 required for C++03 support. See:
+    # https://github.com/easybuilders/easybuild-easyconfigs/pull/15265#issue-1201152246
+    ('Boost', '1.75.0'),
 ]
 
 dependencies = [

--- a/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-12.2.0.eb
+++ b/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-12.2.0.eb
@@ -1,0 +1,45 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+name = 'Cufflinks'
+version = '20190706'
+local_commit = 'dc3b0cb'
+
+homepage = 'http://cole-trapnell-lab.github.io/%(namelower)s/'
+description = "Transcript assembly, differential expression, and differential regulation for RNA-Seq"
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'cole-trapnell-lab'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': '%s.tar.gz' % local_commit, 'filename': SOURCE_TAR_GZ}]
+checksums = ['444c632083a473fe4fd99ff189cef5bbd95daee0912e8eefe79534bf225fbcb6']
+
+builddependencies = [
+    ('Eigen', '3.4.0'),
+    ('Autotools', '20220317'),
+    ('SAMtools', '1.17'),
+    ('Boost', '1.81.0'),
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('HTSlib', '1.17'),
+]
+
+preconfigopts = 'autoreconf -i && export LIBS="${LIBS} -lhts" && export CFLAGS="$CFLAGS -fcommon" && '
+configopts = '--with-boost=${EBROOTBOOST} --with-bam=${EBROOTSAMTOOLS}'
+
+buildopts = "BOOST_FILESYSTEM_LIB=$EBROOTBOOST/lib/libboost_filesystem.a "
+buildopts += "BOOST_SERIALIZATION_LIB=$EBROOTBOOST/lib/libboost_serialization.a "
+buildopts += "BOOST_SYSTEM_LIB=$EBROOTBOOST/lib/libboost_system.a "
+buildopts += "BOOST_THREAD_LIB=$EBROOTBOOST/lib/libboost_thread.a "
+
+sanity_check_paths = {
+    'files': ['bin/cufflinks'],
+    'dirs': []
+}
+
+sanity_check_commands = ["cufflinks 2>&1 | grep 'Usage:.* cufflinks'"]
+
+moduleclass = 'bio'

--- a/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-12.2.0.eb
+++ b/easyconfigs/c/Cufflinks/Cufflinks-20190706-GCC-12.2.0.eb
@@ -8,17 +8,22 @@ homepage = 'http://cole-trapnell-lab.github.io/%(namelower)s/'
 description = "Transcript assembly, differential expression, and differential regulation for RNA-Seq"
 
 toolchain = {'name': 'GCC', 'version': '12.2.0'}
-toolchainopts = {'pic': True}
+toolchainopts = {'pic': True, 'cstd': 'c++17'}
 
 github_account = 'cole-trapnell-lab'
 source_urls = [GITHUB_LOWER_SOURCE]
 sources = [{'download_filename': '%s.tar.gz' % local_commit, 'filename': SOURCE_TAR_GZ}]
-checksums = ['444c632083a473fe4fd99ff189cef5bbd95daee0912e8eefe79534bf225fbcb6']
+patches = ['Cufflinks-20190706-AM_INIT_AUTOMAKE.patch']
+checksums = [
+    {'Cufflinks-20190706.tar.gz': '444c632083a473fe4fd99ff189cef5bbd95daee0912e8eefe79534bf225fbcb6'},
+    {'Cufflinks-20190706-AM_INIT_AUTOMAKE.patch': '3a9c0d39969d5c32da1b35c2e4753b456507a5a5395f291a6264dfe6e38ce146'},
+]
 
 builddependencies = [
     ('Eigen', '3.4.0'),
     ('Autotools', '20220317'),
     ('SAMtools', '1.17'),
+    ('Subversion', '1.14.3'),
     ('Boost', '1.81.0'),
 ]
 

--- a/easyconfigs/s/SCons/SCons-4.4.0_install_man_pages_correctly.patch
+++ b/easyconfigs/s/SCons/SCons-4.4.0_install_man_pages_correctly.patch
@@ -1,0 +1,15 @@
+Install the man pages in the correct directory.
+
+Åke Sandgren, 2022-10-27
+diff -ru SCons-4.4.0.orig/setup.cfg SCons-4.4.0/setup.cfg
+--- SCons-4.4.0.orig/setup.cfg	2022-07-30 23:16:02.000000000 +0200
++++ SCons-4.4.0/setup.cfg	2022-10-27 11:55:33.457877253 +0200
+@@ -58,7 +58,7 @@
+ SCons.Tool.docbook = *.*
+ 
+ [options.data_files]
+-. = scons.1
++man/man1 = scons.1
+ 	scons-time.1
+ 	sconsign.1
+ 

--- a/easyconfigs/s/SCons/SCons-4.5.2-GCCcore-12.2.0.eb
+++ b/easyconfigs/s/SCons/SCons-4.5.2-GCCcore-12.2.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'PythonBundle'
+
+name = 'SCons'
+version = '4.5.2'
+
+homepage = 'https://www.scons.org'
+description = "SCons is a software construction tool."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+builddependencies = [('binutils', '2.39')]
+
+dependencies = [('Python', '3.10.8')]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    (name, version, {
+        'modulename': False,
+        'patches': ['SCons-4.4.0_install_man_pages_correctly.patch'],
+        'checksums': [
+            {'SCons-4.5.2.tar.gz': '813360b2bce476bc9cc12a0f3a22d46ce520796b352557202cb07d3e402f5458'},
+            {'SCons-4.4.0_install_man_pages_correctly.patch':
+             '9d216c2ea8e152ae1531593b17adc4042eb88f1d9524d7f3b08ace5137d6d5e7'},
+        ],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scons', 'bin/sconsign'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s'],
+}
+
+sanity_check_commands = ["scons --help"]
+
+moduleclass = 'devel'

--- a/easyconfigs/s/Serf/Serf-1.3.10-GCCcore-12.2.0.eb
+++ b/easyconfigs/s/Serf/Serf-1.3.10-GCCcore-12.2.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'SCons'
+name = 'Serf'
+version = '1.3.10'
+
+homepage = 'https://serf.apache.org/'
+description = """The serf library is a high performance C-based HTTP client library
+ built upon the Apache Portable Runtime (APR) library"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://archive.apache.org/dist/%(namelower)s']
+sources = [SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('Python', '3.10.8'),
+    ('SCons', '4.5.2'),
+]
+
+dependencies = [
+    ('APR', '1.7.4'),
+    ('APR-util', '1.6.3'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+]
+
+buildopts = "APR=$EBROOTAPR/bin/apr-1-config APU=$EBROOTAPRMINUTIL/bin/apu-1-config"
+
+sanity_check_paths = {
+    'files': ['include/serf-1/serf.h'] +
+             ['lib/libserf-1.%s' % x for x in ['a', 'so']],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easyconfigs/s/Subversion/Subversion-1.12.0-no_swig.patch
+++ b/easyconfigs/s/Subversion/Subversion-1.12.0-no_swig.patch
@@ -1,0 +1,21 @@
+# Only way to disable SWIG/python bindings as --without-swig does nothing
+# Mikael Öhman <micketeer@gmail.com>, 2019-04-27
+--- configure.ac.orig	2019-04-27 22:26:56.185082267 +0200
++++ configure.ac	2019-04-27 22:27:14.038138415 +0200
+@@ -1341,11 +1341,11 @@
+   fi
+ fi
+ 
+-SVN_CHECK_SWIG
+-AC_ARG_VAR(SWIG_FEATURES, [SWIG feature flags common to all bindings])
+-AC_ARG_VAR(SWIG_RB_FEATURES, [SWIG feature flags specific to Ruby bindings])
+-AC_ARG_VAR(SWIG_PL_FEATURES, [SWIG feature flags specific to Perl bindings])
+-AC_ARG_VAR(SWIG_PY_FEATURES, [SWIG feature flags specific to Python bindings])
++#SVN_CHECK_SWIG
++#AC_ARG_VAR(SWIG_FEATURES, [SWIG feature flags common to all bindings])
++#AC_ARG_VAR(SWIG_RB_FEATURES, [SWIG feature flags specific to Ruby bindings])
++#AC_ARG_VAR(SWIG_PL_FEATURES, [SWIG feature flags specific to Perl bindings])
++#AC_ARG_VAR(SWIG_PY_FEATURES, [SWIG feature flags specific to Python bindings])
+ 
+ SVN_CHECK_CTYPESGEN
+ 

--- a/easyconfigs/s/Subversion/Subversion-1.14.3-GCCcore-12.2.0.eb
+++ b/easyconfigs/s/Subversion/Subversion-1.14.3-GCCcore-12.2.0.eb
@@ -1,0 +1,46 @@
+easyblock = 'ConfigureMake'
+
+name = 'Subversion'
+version = '1.14.3'
+
+homepage = 'https://subversion.apache.org/'
+description = " Subversion is an open source version control system."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = [
+    'https://apache.belnet.be/%(namelower)s',
+    'http://www.eu.apache.org/dist/%(namelower)s',
+    'http://www.us.apache.org/dist/%(namelower)s',
+    'https://archive.apache.org/dist/%(namelower)s',
+]
+sources = [SOURCELOWER_TAR_BZ2]
+patches = ['Subversion-1.12.0-no_swig.patch']
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('APR', '1.7.4'),
+    ('APR-util', '1.6.3'),
+    ('SQLite', '3.39.4'),
+    ('zlib', '1.2.12'),
+    ('lz4', '1.9.4'),
+    ('utf8proc', '2.8.0'),
+    ('Serf', '1.3.10'),
+    ('util-linux', '2.38.1'),
+]
+
+preconfigopts = './autogen.sh && '
+
+configopts = "--with-apr=$EBROOTAPR/bin/apr-1-config --with-apr-util=$EBROOTAPRMINUTIL/bin/apu-1-config "
+configopts += "--with-zlib=$EBROOTZLIB --with-lz4=$EBROOTLZ4 --with-serf=$EBROOTSERF"
+
+sanity_check_paths = {
+    'files': ["bin/svn", "bin/svnversion"],
+    'dirs': [],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1468548 - `Cufflinks-20190706-GCC-12.2.0.eb`

- As upsteam (11.2.0 version) with only the deps version-bumped for 2022b/GCC-12.2.0.
- Note: uses older Boost version for compatibility with C++03

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
