### PR TITLE
Rebuild of DeepLabCut for INC1473012

### DIFF
--- a/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a-CUDA-11.7.0.eb
+++ b/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a-CUDA-11.7.0.eb
@@ -76,7 +76,8 @@ exts_list = [
 
 modloadmsg = """
 Please do:
-cp $EBROOTDEEPLABCUT/lib/python3.10/site-packages/deeplabcut/pose_estimation_tensorflow/models/pretrained/pretrained_model_urls.yaml ./
+cp $EBROOTDEEPLABCUT/lib/python3.10/site-packages/deeplabcut/pose_estimation_tensorflow/models/
+pretrained/pretrained_model_urls.yaml ./
 To copy this file into your project directory
 """
 moduleclass = 'lib'

--- a/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a-CUDA-11.7.0.eb
+++ b/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a-CUDA-11.7.0.eb
@@ -65,11 +65,18 @@ exts_list = [
         'checksums': ['964cde4b7728a408dcd5c841ab6b93d95137ab4b60db28b10400f86286bfeb8b'],
     }),
     (name, version, {
-        'preinstallopts': 'sed -i "s|torch<=1.12|torch|" setup.py && ',
+        'patches': ['%(name)s-%(version)s_hpc-fix.patch'],
         'source_tmpl': '%(namelower)s-%(version)s.tar.gz',
-        'checksums': ['c4479f05b3c917a6198c1abbb6ea0ac580ce4b02fe1d068e0215b1984aa8e385'],
+        'checksums': [
+            {'deeplabcut-2.3.6.tar.gz': 'c4479f05b3c917a6198c1abbb6ea0ac580ce4b02fe1d068e0215b1984aa8e385'},
+            {'DeepLabCut-2.3.6_hpc-fix.patch': 'd24154e6a6f9ef56adeb40a8f0c80e37c658f701dc93d49bb45a8bd56be8dca6'},
+        ],
     }),
 ]
 
-
+modloadmsg = """
+Please do:
+cp $EBROOTDEEPLABCUT/lib/python3.10/site-packages/deeplabcut/pose_estimation_tensorflow/models/pretrained/pretrained_model_urls.yaml ./
+To copy this file into your project directory
+"""
 moduleclass = 'lib'

--- a/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a.eb
+++ b/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a.eb
@@ -73,7 +73,8 @@ exts_list = [
 
 modloadmsg = """
 Please do:
-cp $EBROOTDEEPLABCUT/lib/python3.10/site-packages/deeplabcut/pose_estimation_tensorflow/models/pretrained/pretrained_model_urls.yaml ./
+cp $EBROOTDEEPLABCUT/lib/python3.10/site-packages/deeplabcut/pose_estimation_tensorflow/models/
+pretrained/pretrained_model_urls.yaml ./
 To copy this file into your project directory
 """
 

--- a/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a.eb
+++ b/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6-foss-2022a.eb
@@ -62,11 +62,19 @@ exts_list = [
         'checksums': ['964cde4b7728a408dcd5c841ab6b93d95137ab4b60db28b10400f86286bfeb8b'],
     }),
     (name, version, {
-        'preinstallopts': 'sed -i "s|torch<=1.12|torch|" setup.py && ',
+        'patches': ['%(name)s-%(version)s_hpc-fix.patch'],
         'source_tmpl': '%(namelower)s-%(version)s.tar.gz',
-        'checksums': ['c4479f05b3c917a6198c1abbb6ea0ac580ce4b02fe1d068e0215b1984aa8e385'],
+        'checksums': [
+            {'deeplabcut-2.3.6.tar.gz': 'c4479f05b3c917a6198c1abbb6ea0ac580ce4b02fe1d068e0215b1984aa8e385'},
+            {'DeepLabCut-2.3.6_hpc-fix.patch': 'd24154e6a6f9ef56adeb40a8f0c80e37c658f701dc93d49bb45a8bd56be8dca6'},
+        ],
     }),
 ]
 
+modloadmsg = """
+Please do:
+cp $EBROOTDEEPLABCUT/lib/python3.10/site-packages/deeplabcut/pose_estimation_tensorflow/models/pretrained/pretrained_model_urls.yaml ./
+To copy this file into your project directory
+"""
 
 moduleclass = 'lib'

--- a/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6_hpc-fix.patch
+++ b/easyconfigs/d/DeepLabCut/DeepLabCut-2.3.6_hpc-fix.patch
@@ -1,0 +1,23 @@
+--- setup.py.old	2024-02-29 14:42:49.357193371 +0000
++++ setup.py	2024-02-29 14:43:12.546184209 +0000
+@@ -40,7 +40,7 @@
+         "scipy>=1.4,<1.11.0",
+         "statsmodels>=0.11",
+         "tables>=3.7.0",
+-        "torch<=1.12",
++        "torch",
+         "tensorpack>=0.11",
+         "tf_slim>=1.1.0",
+         "tqdm",
+
+--- deeplabcut/utils/auxfun_models.py.old	2024-02-29 12:39:21.669565000 +0000
++++ deeplabcut/utils/auxfun_models.py	2024-02-29 12:39:59.369866000 +0000
+@@ -25,7 +25,7 @@
+ 
+ 
+ # This dictionary maps the model types to the file locations where the models exist.
+-MODEL_BASE_PATH = Path("pose_estimation_tensorflow") / "models" / "pretrained"
++MODEL_BASE_PATH = Path.cwd()
+ MODELTYPE_FILEPATH_MAP = {
+     "resnet_50": MODEL_BASE_PATH / "resnet_v1_50.ckpt",
+     "resnet_101": MODEL_BASE_PATH / "resnet_v1_101.ckpt",


### PR DESCRIPTION
For INC1473012- `DeepLabCut-2.3.6-foss-2022a-CUDA-11.7.0.eb DeepLabCut-2.3.6-foss-2022a.eb`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

**Note:** This is a rebuild. CUDA version is icelake only

The change is in place to stop it trying to install in the install directory, this has worked for my tests. It might require further editing from response from the user