### PR TITLE
flowTrans

### DIFF
--- a/easyconfigs/f/flowTrans/RProtoBufLib-2.8.0_fix-protobuf-build.patch
+++ b/easyconfigs/f/flowTrans/RProtoBufLib-2.8.0_fix-protobuf-build.patch
@@ -1,0 +1,41 @@
+Replace the protobuf map files so that the required symbols are extern "C++"
+Fix from https://github.com/protocolbuffers/protobuf/issues/5144#issuecomment-688723405
+
+Add extra path to includes.
+
+Patch by Simon Branford (University of Birmingham)
+--- RProtoBufLib/configure.orig	2021-06-05 10:58:25.972255000 +0100
++++ RProtoBufLib/configure	2021-06-05 11:08:16.635526105 +0100
+@@ -2867,6 +2867,23 @@
+ 	gzip -dc ${PBTGZNAME} | tar -xf -
+ fi;
+ 
++mapfiles="libprotoc.map libprotobuf-lite.map libprotobuf.map"
++for mapfile in ${mapfiles}; do
++    cat << EOF > protobuf-3.8.0/src/${mapfile}
++{
++  global:
++    extern "C++" {
++      *google*;
++    };
++    scc_info_*;
++    descriptor_table_*;
++
++  local:
++    *;
++};
++EOF
++done
++
+ #run this bootstrap script to update all the gnu auto build files (e.g.  automake symlinked fils (e.g. ./compile), alocal.m4,etc... )
+ cd ${BASEPBNAME}
+ #./autogen.sh
+--- RProtoBufLib/src/Makevars.in.orig	2021-06-05 11:58:07.587850000 +0100
++++ RProtoBufLib/src/Makevars.in	2021-06-05 11:58:57.608744000 +0100
+@@ -1,5 +1,5 @@
+ CXX_STD = CXX11
+-PKG_CPPFLAGS =-I../inst/include/ -I@PBBUILD@/include/
++PKG_CPPFLAGS =-I../inst/include/ -I@PBBUILD@/include/ -I@PBBUILD@/src
+ #expose headers in installed package include folder
+ USER_INCLUDE = ${R_PACKAGE_DIR}/include
+ USER_LIB_DIR = ${R_PACKAGE_DIR}/lib${R_ARCH}/

--- a/easyconfigs/f/flowTrans/flowTrans-1.52.0-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/f/flowTrans/flowTrans-1.52.0-foss-2022b-R-4.3.1.eb
@@ -1,0 +1,61 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'flowTrans'
+version = '1.52.0'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://bioconductor.org/packages/3.17/bioc/html/flowTrans.html"
+description = """Profile maximum likelihood estimation of parameters for flow cytometry data transformations."""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('R', '4.3.1'),
+    ('R-bundle-Bioconductor', '3.17', '-R-%(rver)s'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://bioconductor.org/packages/3.17/bioc/src/contrib/',
+        'https://bioconductor.org/packages/3.17/bioc/src/contrib/Archive/%(name)s',
+        'https://bioconductor.org/packages/3.17/data/annotation/src/contrib/',
+        'https://bioconductor.org/packages/3.17/data/experiment/src/contrib/',
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# Order is important!
+exts_list = [
+    ('RProtoBufLib', '2.12.1', {
+        'patches': ['RProtoBufLib-2.8.0_fix-protobuf-build.patch'],
+        'checksums': [
+            {'RProtoBufLib_2.12.1.tar.gz': 'b5c1c2d5ea6284ec33bda7af86fa99554687451287aabbacf91ed325a3ecf624'},
+            {'RProtoBufLib-2.8.0_fix-protobuf-build.patch':
+             '8775d74e2288000c57575f4ef45a875b4a377ac02f89efa947699ea786bedf64'},
+        ],
+    }),
+    ('cytolib', '2.12.1', {
+        'checksums': ['1fcf5c4f45411321fd4fd8b8a0ace9955ab195c8f1a3fdcf037f8b345311db55'],
+    }),
+    ('flowCore', '2.12.2', {
+        'checksums': ['1064a2941dbca4a25ff129ca8d62c9341b545aa070d6221987b2edeac3d57dfc'],
+    }),
+    (name, version, {
+        'checksums': ['64ccd4a230a670818adbf96f0f15102f211c1f81e192d1d1ad949f926c39b1d6'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['%(name)s/R/%(name)s'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1476235 - `EBFILENAME`

Notes:
- cytolib and rprotbuflib are available in bioconductor but newer versions of both are required for flowTrans 1.52.0

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
