### PR TITLE
Add RUVSeq to 2022b RStudio modules

### DIFF
--- a/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2022b-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2022b-foss-2022b-R-4.3.1.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('MOFA2', '1.10.0', versionsuffix),
     ('smotefamily', '1.3.1', versionsuffix),
     ('MAST', '1.26.0', versionsuffix),
+    ('RUVSeq', '1.34.0', versionsuffix),
 ]
 
 moduleclass = 'bio'


### PR DESCRIPTION
For INC1482500 - `BEAR-R-bio-2022b-foss-2022b-R-4.3.1.eb`

(RUVSeq is already built - using RUVSeq-1.34.0-foss-2022b-R-4.3.1.eb)

* [ ] Assigned to reviewer

