### PR TITLE
FHI-aims

### DIFF
--- a/easyconfigs/f/FHI-aims/FHI-aims-231212_1-intel-2022b.eb
+++ b/easyconfigs/f/FHI-aims/FHI-aims-231212_1-intel-2022b.eb
@@ -1,0 +1,62 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Authors::   Dugan Witherick (University of Warwick)
+# Updated to 210716_3
+# J. Sassmannshausen (Imperial College London/UK)
+##
+easyblock = 'CMakeMake'
+
+name = 'FHI-aims'
+version = '231212_1'
+
+homepage = 'https://fhi-aims.org/'
+description = """FHI-aims is an efficient, accurate all-electron,
+full-potential electronic structure code package for computational molecular
+and materials science (non-periodic and periodic systems). The code supports
+DFT (semilocal and hybrid) and many-body perturbation theory. FHI-aims is
+particularly efficient for molecular systems and nanostructures, while
+maintaining high numerical accuracy for all production tasks. Production
+calculations handle up to several thousand atoms and can efficiently use (ten)
+thousands of cores. 
+"""
+
+toolchain = {'name': 'intel', 'version': '2022b'}
+toolchainopts = {'opt': True, 'precise': True}
+
+download_instructions = """
+The source code must be downloaded manually from the FHI-aims club
+(https://fhi-aims.org/get-the-code-menu/login).
+Access to the FHI-aims club requires a valid license and registration.
+Details on available license options and how to register to access
+FHI-aims club may be found at:
+https://fhi-aims.org/get-the-code-menu/get-the-code """
+
+sources = ['%(namelower)s.%(version)s.tar']
+checksums = ['7d76bc2f3fadcbc41983dfd83b64a853e5e423a58630dd8ec95576855a6b567d']
+
+builddependencies = [
+    ('CMake', '3.24.3')
+]
+
+configopts = ' -DCMAKE_Fortran_COMPILER="$MPIF90" '
+configopts += ' -DCMAKE_C_COMPILER="$MPICC" '
+configopts += ' -DCMAKE_CXX_COMPILER="$MPICXX" '
+configopts += ' -DLIBS="mkl_scalapack_lp64 mkl_blacs_intelmpi_lp64 mkl_intel_lp64 mkl_sequential mkl_core" '
+configopts += ' -DLIB_PATHS="$CMAKE_LIBRARY_PATH" '
+configopts += ' -DCMAKE_C_FLAGS="$CFLAGS -ip" '
+configopts += ' -DCMAKE_Fortran_FLAGS="$FFLAGS -ip" '
+configopts += ' -DFortran_MIN_FLAGS="-O0 -fp-model precise" '
+configopts += ' -DTARGET_NAME="aims.x" '
+configopts += ' -DELPA2_KERNEL="AVX512" '
+
+postinstallcmds = ["cp -ar %(builddir)s/%(namelower)s.%(version)s/{CHANGELOG.md,doc,external} %(installdir)s/",
+                   "cp -ar %(builddir)s/%(namelower)s.%(version)s/{regression_tests,species_defaults} %(installdir)s/",
+                   "cp -ar %(builddir)s/%(namelower)s.%(version)s/{testcases,utilities} %(installdir)s/"]
+
+sanity_check_paths = {
+    'files': ['bin/aims.x'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easyconfigs/f/FHI-aims/FHI-aims-231212_1-intel-2022b.eb
+++ b/easyconfigs/f/FHI-aims/FHI-aims-231212_1-intel-2022b.eb
@@ -18,7 +18,7 @@ DFT (semilocal and hybrid) and many-body perturbation theory. FHI-aims is
 particularly efficient for molecular systems and nanostructures, while
 maintaining high numerical accuracy for all production tasks. Production
 calculations handle up to several thousand atoms and can efficiently use (ten)
-thousands of cores. 
+thousands of cores.
 """
 
 toolchain = {'name': 'intel', 'version': '2022b'}
@@ -44,8 +44,8 @@ configopts += ' -DCMAKE_C_COMPILER="$MPICC" '
 configopts += ' -DCMAKE_CXX_COMPILER="$MPICXX" '
 configopts += ' -DLIBS="mkl_scalapack_lp64 mkl_blacs_intelmpi_lp64 mkl_intel_lp64 mkl_sequential mkl_core" '
 configopts += ' -DLIB_PATHS="$CMAKE_LIBRARY_PATH" '
-configopts += ' -DCMAKE_C_FLAGS="$CFLAGS -ip" '
-configopts += ' -DCMAKE_Fortran_FLAGS="$FFLAGS -ip" '
+configopts += ' -DCMAKE_C_FLAGS="$CFLAGS" '
+configopts += ' -DCMAKE_Fortran_FLAGS="$FFLAGS" '
 configopts += ' -DFortran_MIN_FLAGS="-O0 -fp-model precise" '
 configopts += ' -DTARGET_NAME="aims.x" '
 configopts += ' -DELPA2_KERNEL="AVX512" '


### PR DESCRIPTION
For INC1484290 - `FHI-aims-231212_1-intel-2022b.eb`

Modified from [upstream version](https://github.com/easybuilders/easybuild-easyconfigs/blob/39a025559ebf3806f08275d55c2a2e862dfa4181/easybuild/easyconfigs/f/FHI-aims/FHI-aims-221103-intel-2022a.eb), bumping the toolchain and removing the deprecated compiler option `-ip`.

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
