### PR TITLE
Rebuild digitalDLSorteR with TensorFlow

### DIFF
--- a/easyconfigs/d/digitalDLSorteR/digitalDLSorteR-1.0.1-foss-2022b-R-4.3.1.eb
+++ b/easyconfigs/d/digitalDLSorteR/digitalDLSorteR-1.0.1-foss-2022b-R-4.3.1.eb
@@ -15,6 +15,7 @@ dependencies = [
     ('R', '4.3.1'),
     ('R-bundle-Bioconductor', '3.17', '-R-%(rver)s'),
     ('Python', '3.10.8'),
+    ('TensorFlow', '2.13.0'),
 ]
 
 exts_defaultclass = 'RPackage'


### PR DESCRIPTION
For INC1487268 - `digitalDLSorteR-1.0.1-foss-2022b-R-4.3.1.eb`

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

**Note:** This is a rebuild