### PR TITLE
Fix to UMI-VarCal and additional dependencies

### DIFF
--- a/easyconfigs/m/msgpack/msgpack-0.5.6-foss-2022b.eb
+++ b/easyconfigs/m/msgpack/msgpack-0.5.6-foss-2022b.eb
@@ -1,0 +1,25 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonPackage'
+
+name = 'msgpack'
+version = '0.5.6'
+
+homepage = "https://pypi.org/project/msgpack"
+description = """MessagePack is an efficient binary serialization format.
+It lets you exchange data among multiple languages like JSON"""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+dependencies = [
+    ('Python', '3.10.8'),
+]
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['0ee8c8c85aa651be3aa0cd005b5931769eaa658c948ce79428766f1bd46ae2c3']
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+moduleclass = 'tools'

--- a/easyconfigs/p/pyfasta/pyfasta-0.5.2-foss-2022b.eb
+++ b/easyconfigs/p/pyfasta/pyfasta-0.5.2-foss-2022b.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonPackage'
+
+name = 'pyfasta'
+version = '0.5.2'
+
+homepage = 'https://pypi.org/project/pyfasta/'
+description = """fast, memory-efficient, pythonic (and command-line) access to fasta sequence files"""
+
+toolchain = {'name': 'foss', 'version': '2022b'}
+
+sources = [SOURCE_TAR_GZ]
+patches = ['pyfasta-0.5.2-resolve_deprecated.patch']
+checksums = [
+    {'pyfasta-0.5.2.tar.gz': 'ab08d75fa90253bc91933d10567d5d9cca2718f4796ef3bdc36b68df0e45b258'},
+    {'pyfasta-0.5.2-resolve_deprecated.patch': 'ac89992a16c4c29af64ecc75e030bffc9062c06fc802ffe1ba6b520eb35250ff'},
+]
+
+use_pip = True
+download_dep_fail = True
+
+dependencies = [
+    ('Python', '3.10.8'),
+    ('SciPy-bundle', '2023.02'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/pyfasta'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+# sanity_check_commands = ['pyfasta extract --help']
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easyconfigs/u/UMI-VarCal/UMI-VarCal-2.8.2-foss-2022b.eb
+++ b/easyconfigs/u/UMI-VarCal/UMI-VarCal-2.8.2-foss-2022b.eb
@@ -16,8 +16,9 @@ dependencies = [
     ('statsmodels', '0.14.0'),
     ('SciPy-bundle', '2023.02'),
     ('Pysam', '0.21.0'),
-    ('msgpack-c', '6.0.0'),
+    ('msgpack', '0.5.6'),
     ('pyfaidx', '0.7.2.1'),
+    ('pyfasta', '0.5.2'),
 ]
 
 source_urls = ["https://gitlab.com/vincent-sater/umi-varcal/-/archive/master"]
@@ -26,8 +27,9 @@ patches = [
     'umi_varcal_func_path.patch',
     'umi_varcal_readme_path.patch',
 ]
+
 checksums = [
-    {'umi-varcal-master.tar.gz': '17622274c2270d1b0c66ebb8ac142764cb4c3b211488d327482979f47a29d879'},
+    {'umi-varcal-master.tar.gz': '6f3dc862acf1da09d6a2552a50cc5e41c242f79f70f719810b21288c01d8c014'},
     {'umi_varcal_func_path.patch': '9ac9a8eee789daef4f64f2d99ec54879c8b1e933adfd69ebd4740d7ad3bc63b3'},
     {'umi_varcal_readme_path.patch': '34ac9fced28a6335fd4aaa9f563bee1de34efd79a3c144b2823084ecbffaf289'},
 ]


### PR DESCRIPTION
For INC1517282 - `msgpack-0.5.6-foss-2022b.eb pyfasta-0.5.2-foss-2022b.eb UMI-VarCal-2.8.2-foss-2022b.eb`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

**Note:** UMI-VarCal is a rebuild