### PR TITLE
fix(cascadelake): use reduced optimisation to avoid comparison failure

### DIFF
--- a/easyconfigs/p/PLINK/PLINK-2.0.0-a.5.17-gfbf-2023a.eb
+++ b/easyconfigs/p/PLINK/PLINK-2.0.0-a.5.17-gfbf-2023a.eb
@@ -12,8 +12,6 @@ toolchain = {'name': 'gfbf', 'version': '2023a'}
 
 
 dependencies = [
-    ('zlib', '1.2.13'),
-    ('zstd', '1.5.5'),
     ('libdeflate', '1.18'),
 ]
 
@@ -30,7 +28,7 @@ components = [
     ('PLINK1', '1.90', {
         'start_dir': '%s-ng-%s/1.9' % (name.lower(), version),
         'buildopts': (
-            'CFLAGS="${CFLAGS} -DDYNAMIC_ZLIB" CXXFLAGS="${CXXFLAGS} -DDYNAMIC_ZLIB" '
+            'CFLAGS="${CFLAGS} -O1 -DDYNAMIC_ZLIB" CXXFLAGS="${CXXFLAGS} -DDYNAMIC_ZLIB" '
             'LDFLAGS="${LDFLAGS} -lm -lpthread -ldl" BLASFLAGS="${LIBBLAS}" ZLIB="-L$EBROOTZLIB/lib -lz"'
         ),
         'files_to_copy': [(['plink'], 'bin')],


### PR DESCRIPTION
 plink1.90

From PR: https://github.com/easybuilders/easybuild-easyconfigs/pull/21590#issuecomment-2457403230

For INC1547323 - `PLINK-2.0.0-a.5.17-gfbf-2023a.eb`

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

2023a and above:
* [ ] EL8-sapphire
