### PR TITLE
NVHPC 24.11 / CUDA 12.6.0 / OpenMPI 4.1.6

### DIFF
--- a/easyconfigs/n/NCCL/NCCL-2.18.3-GCCcore-12.3.0-CUDA-12.6.0.eb
+++ b/easyconfigs/n/NCCL/NCCL-2.18.3-GCCcore-12.3.0-CUDA-12.6.0.eb
@@ -1,0 +1,35 @@
+name = 'NCCL'
+version = '2.18.3'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://developer.nvidia.com/nccl'
+description = """The NVIDIA Collective Communications Library (NCCL) implements multi-GPU and multi-node collective
+communication primitives that are performance optimized for NVIDIA GPUs."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+github_account = 'NVIDIA'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s-1.tar.gz']
+patches = [
+    'NCCL-2.16.2_fix-cpuid.patch',
+    'NCCL-2.18.3_fix-cudaMemcpyAsync.patch',
+]
+checksums = [
+    ('6477d83c9edbb34a0ebce6d751a1b32962bc6415d75d04972b676c6894ceaef9',
+     'b4f5d7d9eea2c12e32e7a06fe138b2cfc75969c6d5c473aa6f819a792db2fc96'),
+    {'NCCL-2.16.2_fix-cpuid.patch': '0459ecadcd32b2a7a000a2ce4f675afba908b2c0afabafde585330ff4f83e277'},
+    {'NCCL-2.18.3_fix-cudaMemcpyAsync.patch': '7dc8d0d1b78e4f8acefbc400860f47432ef67c225b50d73c732999c23483de90'},
+]
+
+builddependencies = [('binutils', '2.40')]
+
+dependencies = [
+    ('CUDA', '12.6.0', '', SYSTEM),
+    ('UCX-CUDA', '1.14.1', versionsuffix),
+]
+
+# default CUDA compute capabilities to use (override via --cuda-compute-capabilities)
+cuda_compute_capabilities = ['5.0', '6.0', '7.0', '7.5', '8.0', '8.6', '9.0']
+
+moduleclass = 'lib'

--- a/easyconfigs/n/NVHPC/NVHPC-24.11-CUDA-12.6.0.eb
+++ b/easyconfigs/n/NVHPC/NVHPC-24.11-CUDA-12.6.0.eb
@@ -1,0 +1,73 @@
+name = 'NVHPC'
+version = '24.11'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://developer.nvidia.com/hpc-sdk/'
+description = """C, C++ and Fortran compilers included with the NVIDIA HPC SDK (previously: PGI)"""
+
+toolchain = SYSTEM
+
+local_tarball_tmpl = 'nvhpc_2024_%%(version_major)s%%(version_minor)s_Linux_%s_cuda_multi.tar.gz'
+# By downloading, you accept the HPC SDK Software License Agreement
+# https://docs.nvidia.com/hpc-sdk/eula/index.html
+# accept_eula = True
+source_urls = ['https://developer.download.nvidia.com/hpc-sdk/%(version)s/']
+sources = [local_tarball_tmpl % '%(arch)s']
+checksums = [
+    {
+        local_tarball_tmpl % 'aarch64':
+            'f2f64e5dec5e90dad5e12a31a992172b0aa19abf872ef1c54a1a437c7008eefb',
+        local_tarball_tmpl % 'x86_64':
+            '0c27d66ed0e2d3007d30ac904922a9abf96475197dc0f4dcc6316d235a1dc0c3',
+    }
+]
+
+local_gccver = '12.3.0'
+dependencies = [
+    ('GCCcore', local_gccver),
+    ('binutils', '2.40', '', ('GCCcore', local_gccver)),
+    # This is necessary to avoid cases where just libnuma.so.1 is present in the system and -lnuma fails
+    ('numactl', '2.0.16', '', ('GCCcore', local_gccver)),
+    ('CUDA', '12.6.0', '', SYSTEM),
+]
+
+module_add_cuda = False
+
+# specify default CUDA version that should be used by NVHPC
+# should match one of the CUDA versions that are included with this NVHPC version
+# (see install_components/Linux_x86_64/$version/cuda/) where $version is the NVHPC version
+# this version can be tweaked from the EasyBuild command line with
+# --try-amend=default_cuda_version="11.0" (for example)
+default_cuda_version = '%(cudaver)s'
+
+# NVHPC EasyBlock supports some features, which can be set via CLI or this easyconfig.
+# The following list gives examples for the easyconfig
+#
+# NVHPC needs CUDA to work. Two options are available: 1) Use NVHPC-bundled CUDA, 2) use system CUDA
+# 1) Bundled CUDA
+#    If no easybuild dependency to CUDA is present, the bundled CUDA is taken. A version needs to be specified with
+#      default_cuda_version = "11.0"
+#    in this easyconfig file; alternatively, it can be specified through the command line during installation with
+#      --try-amend=default_cuda_version="10.2"
+# 2) CUDA provided via EasyBuild
+#    Use CUDA as a dependency, for example
+#      dependencies = [('CUDA', '11.5.0')]
+#    The parameter default_cuda_version still can be set as above.
+#    If not set, it will be deduced from the CUDA module (via $EBVERSIONCUDA)
+#
+# Define a NVHPC-default Compute Capability
+#   cuda_compute_capabilities = "8.0"
+# Can also be specified on the EasyBuild command line via --cuda-compute-capabilities=8.0
+# Only single values supported, not lists of values!
+#
+# Options to add/remove things to/from environment module (defaults shown)
+#   module_byo_compilers = False  # Remove compilers from PATH (Bring-your-own compilers)
+#   module_nvhpc_own_mpi = False  # Add NVHPC's own pre-compiled OpenMPI
+#   module_add_math_libs = False  # Add NVHPC's math libraries (which should be there from CUDA anyway)
+#   module_add_profilers = False  # Add NVHPC's NVIDIA Profilers
+#   module_add_nccl = False       # Add NVHPC's NCCL library
+#   module_add_nvshmem = False    # Add NVHPC's NVSHMEM library
+#   module_add_cuda = False       # Add NVHPC's bundled CUDA
+
+# this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
+moduleclass = 'compiler'

--- a/easyconfigs/o/OpenMPI/OpenMPI-4.1.6-NVHPC-24.11-CUDA-12.6.0.eb
+++ b/easyconfigs/o/OpenMPI/OpenMPI-4.1.6-NVHPC-24.11-CUDA-12.6.0.eb
@@ -1,0 +1,67 @@
+name = 'OpenMPI'
+version = '4.1.6'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'NVHPC', 'version': '24.11-CUDA-12.6.0'}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    'OpenMPI-4.1.1_build-with-internal-cuda-header.patch',
+    'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch',
+    'OpenMPI-4.1.x_add_atomic_wmb.patch',
+]
+checksums = [
+    {'openmpi-4.1.6.tar.bz2': 'f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415'},
+    {'OpenMPI-4.1.1_build-with-internal-cuda-header.patch':
+     '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83'},
+    {'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch':
+     'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e'},
+    {'OpenMPI-4.1.x_add_atomic_wmb.patch': '9494bbc546d661ba5189e44b4c84a7f8df30a87cdb9d96ce2e73a7c8fecba172'},
+]
+
+builddependencies = [
+    ('pkgconf', '1.9.5'),
+    ('Perl', '5.36.1'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('hwloc', '2.9.1'),
+    ('libevent', '2.1.12'),
+    ('UCX', '1.14.1'),
+    ('UCX-CUDA', '1.14.1', '-CUDA-%(cudaver)s'),
+    ('libfabric', '1.18.0'),
+    ('PMIx', '4.2.4'),
+    ('UCC', '1.2.0'),
+    ('UCC-CUDA', '1.2.0', '-CUDA-%(cudaver)s'),
+]
+
+# Update configure to include changes from the "internal-cuda" patch
+# by running a subset of autogen.pl sufficient to achieve this
+# without doing the full, long-running regeneration.
+preconfigopts = ' && '.join([
+    'cd config',
+    'autom4te --language=m4sh opal_get_version.m4sh -o opal_get_version.sh',
+    'cd ..',
+    'autoconf',
+    'autoheader',
+    'aclocal',
+    'automake',
+    ''
+])
+
+# CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
+configopts = '--with-cuda=internal '
+configopts += ' CC=pgcc CXX=pgc++ FC=pgfortran'
+
+# disable MPI1 compatibility for now, see what breaks...
+# configopts += '--enable-mpi1-compatibility '
+
+# to enable SLURM integration (site-specific)
+# configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'
+
+moduleclass = 'mpi'

--- a/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.6.0.eb
+++ b/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.6.0.eb
@@ -6,7 +6,7 @@ versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://www.openucx.org/'
 description = """UCC (Unified Collective Communication) is a collective
-communication operations API and library that is flexible, complete, and 
+communication operations API and library that is flexible, complete, and
 feature-rich for current and emerging programming models and runtimes.
 
 This module adds the UCC CUDA support.

--- a/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.6.0.eb
+++ b/easyconfigs/u/UCC-CUDA/UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.6.0.eb
@@ -1,0 +1,55 @@
+easyblock = 'ConfigureMake'
+
+name = 'UCC-CUDA'
+version = '1.2.0'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://www.openucx.org/'
+description = """UCC (Unified Collective Communication) is a collective
+communication operations API and library that is flexible, complete, and 
+feature-rich for current and emerging programming models and runtimes.
+
+This module adds the UCC CUDA support.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucc/archive/refs/tags']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    '%(name)s-%(version)s_link_against_existing_UCC_libs.patch',
+]
+checksums = [
+    {'v1.2.0.tar.gz': 'c1552797600835c0cf401b82dc89c4d27d5717f4fb805d41daca8e19f65e509d'},
+    {'UCC-CUDA-1.2.0_link_against_existing_UCC_libs.patch':
+     '84157be5eae96d2501df076bcf0598b104adf80abeca028a144c4fb098638207'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('UCC', version),
+    ('CUDA',  '12.6.0', '', SYSTEM),
+    ('UCX-CUDA', '1.14.1', '-CUDA-%(cudaver)s'),
+    ('NCCL', '2.18.3', '-CUDA-%(cudaver)s'),
+]
+
+preconfigopts = "./autogen.sh && "
+
+buildopts = '-C src/components/mc/cuda V=1 && make -C src/components/tl/nccl V=1'
+installopts = '-C src/components/mc/cuda && make -C src/components/tl/nccl install'
+
+sanity_check_paths = {
+    'files': ['lib/ucc/libucc_mc_cuda.%s' % SHLIB_EXT, 'lib/ucc/libucc_tl_nccl.%s' % SHLIB_EXT],
+    'dirs': ['lib']
+}
+
+sanity_check_commands = ["ucc_info -c"]
+
+modextrapaths = {'EB_UCC_EXTRA_COMPONENT_PATH': 'lib/ucc'}
+
+moduleclass = 'lib'

--- a/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.6.0.eb
+++ b/easyconfigs/u/UCX-CUDA/UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.6.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'EB_UCX_Plugins'
+
+name = 'UCX-CUDA'
+version = '1.14.1'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'http://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+
+This module adds the UCX CUDA support.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = [{'filename': 'ucx-%(version)s.tar.gz', 'alt_location': 'UCX'}]
+patches = ['%(name)s-1.11.0_link_against_existing_UCX_libs.patch']
+checksums = [
+    {'ucx-1.14.1.tar.gz': 'baa0634cafb269a3112f626eb226bcd2ca8c9fcf0fec3b8e2a3553baad5f77aa'},
+    {'UCX-CUDA-1.11.0_link_against_existing_UCX_libs.patch':
+     '457187fa020e526609ba91e7750c9941d57bd57d60d6eed317b40ad8824aca93'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+    ('pkgconf', '1.9.5'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('UCX', version),
+    ('CUDA', '12.6.0', '', SYSTEM),
+    ('GDRCopy', '2.3.1'),
+]
+
+
+moduleclass = 'lib'


### PR DESCRIPTION
For INC1558425

NVHPC uses a dfferent GCC base to upstream (12.3.0 instead of 13.3.0).

* [x] Assigned to reviewer

`OpenMPI-4.1.6-NVHPC-24.11-CUDA-12.6.0.eb`:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-sapphire
