### PR TITLE
DMRcaller and methylKit for bioconductor 3.19

### DIFF
--- a/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2023a-foss-2023a-R-4.4.1.eb
+++ b/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2023a-foss-2023a-R-4.4.1.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 dependencies = [
     ('R', '4.4.1'),
     ('R-bundle-Bioconductor', '3.19', versionsuffix),
+    ('DMRcaller', '1.36.0', versionsuffix),
+    ('methylKit', '1.30.0', versionsuffix),
 ]
 
 moduleclass = 'bio'

--- a/easyconfigs/d/DMRcaller/DMRcaller-1.36.0-foss-2023a-R-4.4.1.eb
+++ b/easyconfigs/d/DMRcaller/DMRcaller-1.36.0-foss-2023a-R-4.4.1.eb
@@ -1,0 +1,49 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'DMRcaller'
+version = '1.36.0'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://bioconductor.org/packages/release/bioc/html/DMRcaller.html"
+description = """Uses Bisulfite sequencing data in two conditions and identifies differentially methylated regions
+ between the conditions in CG and non-CG context. The input is the CX report files produced by Bismark
+  and the output is a list of DMRs stored as GRanges objects."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('R', '4.4.1'),
+    ('R-bundle-Bioconductor', '3.19', '-R-%(rver)s'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://bioconductor.org/packages/3.19/bioc/src/contrib/',
+        'https://bioconductor.org/packages/3.19/bioc/src/contrib/Archive/%(name)s',
+        'https://bioconductor.org/packages/3.19/data/annotation/src/contrib/',
+        'https://bioconductor.org/packages/3.19/data/experiment/src/contrib/',
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# Order is important!
+exts_list = [
+    (name, version, {
+        'checksums': ['50685980c66a18a915ab4895f1d485175161f7b5503b6ee3ab4477e3cfa93d65'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['DMRcaller/R/DMRcaller'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easyconfigs/m/methylKit/methylKit-1.30.0-foss-2023a-R-4.4.1.eb
+++ b/easyconfigs/m/methylKit/methylKit-1.30.0-foss-2023a-R-4.4.1.eb
@@ -1,0 +1,52 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'methylKit'
+version = '1.30.0'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://bioconductor.org/packages/release/bioc/html/methylKit.html"
+description = """methylKit is an R package for DNA methylation analysis and annotation from high-throughput bisulfite sequencing.
+ The package is designed to deal with sequencing data from RRBS and its variants, but also target-capture methods and whole
+ genome bisulfite sequencing."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('R', '4.4.1'),
+    ('R-bundle-Bioconductor', '3.19', '-R-%(rver)s'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://bioconductor.org/packages/3.19/bioc/src/contrib/',
+        'https://bioconductor.org/packages/3.19/bioc/src/contrib/Archive/%(name)s',
+        'https://bioconductor.org/packages/3.19/data/annotation/src/contrib/',
+        'https://bioconductor.org/packages/3.19/data/experiment/src/contrib/',
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+# Order is important!
+exts_list = [
+    ('fastseg', '1.50.0', {
+        'checksums': ['4df86c840be7fab646a1792d394884c8963d5d91cbbd53f0215e8284cf3ff40d'],
+    }),
+    (name, version, {
+        'checksums': ['b2b9989132f2861f7ed1d0bccff5cdc2f8d3aea670203cf092334a364cdc0d00'],
+    }),
+]
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+sanity_check_paths = {
+    'files': ['methylKit/R/methylKit'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easyconfigs/m/methylKit/methylKit-1.30.0-foss-2023a-R-4.4.1.eb
+++ b/easyconfigs/m/methylKit/methylKit-1.30.0-foss-2023a-R-4.4.1.eb
@@ -6,9 +6,9 @@ version = '1.30.0'
 versionsuffix = '-R-%(rver)s'
 
 homepage = "https://bioconductor.org/packages/release/bioc/html/methylKit.html"
-description = """methylKit is an R package for DNA methylation analysis and annotation from high-throughput bisulfite sequencing.
- The package is designed to deal with sequencing data from RRBS and its variants, but also target-capture methods and whole
- genome bisulfite sequencing."""
+description = """methylKit is an R package for DNA methylation analysis and annotation from high-throughput
+ bisulfite sequencing. The package is designed to deal with sequencing data from RRBS and its variants,
+ but also target-capture methods and whole genome bisulfite sequencing."""
 
 toolchain = {'name': 'foss', 'version': '2023a'}
 


### PR DESCRIPTION
For INC1559011 - 

- `time eb DMRcaller-1.36.0-foss-2023a-R-4.4.1.eb`

- `time eb methylKit-1.30.0-foss-2023a-R-4.4.1.eb`

and add to BEAR-r-bio

- `eb BEAR-R-bio-2023a-foss-2023a-R-4.4.1.eb --rebuild`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

2023a and above:
* [ ] EL8-sapphire
