### PR TITLE
ASE newer version for numpy version fix

### DIFF
--- a/easyconfigs/a/ASE/ASE-3.23.0-foss-2023a.eb
+++ b/easyconfigs/a/ASE/ASE-3.23.0-foss-2023a.eb
@@ -1,0 +1,49 @@
+easyblock = 'PythonBundle'
+
+name = 'ASE'
+version = '3.23.0'
+
+homepage = 'https://wiki.fysik.dtu.dk/ase'
+description = """ASE is a python package providing an open source Atomic Simulation Environment
+ in the Python scripting language.
+
+From version 3.20.1 we also include the ase-ext package, it contains optional reimplementations
+in C of functions in ASE.  ASE uses it automatically when installed."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
+    ('SciPy-bundle', '2023.07'),
+    ('Flask', '2.3.3'),
+    ('matplotlib', '3.7.2'),
+    ('Tkinter', '%(pyver)s'),     # Needed by GUI of ASE
+    ('spglib-python', '2.1.0'),  # optional
+    ('mpi4py', '3.1.4'),  # optional
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('pytest-mock', '3.11.1', {
+        'checksums': ['7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f'],
+    }),
+    ('ase', version, {
+        'checksums': ['91a2aa31d89bd90b0efdfe4a7e84264f32828b2abfc9f38e65e041ad76fec8ae'],
+    }),
+    ('ase-ext', '20.9.0', {
+        'checksums': ['a348b0e42cf9fdd11f04b3df002b0bf150002c8df2698ff08d3c8fc7a1223aed'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/ase'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+# make sure Tkinter is available, otherwise 'ase gui' will not work
+sanity_check_commands = ["python -c 'import tkinter' "]
+
+moduleclass = 'chem'


### PR DESCRIPTION
For INC1555168 - `ASE-3.23.0-foss-2023a.eb`

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

2023a and above:
* [ ] EL8-sapphire

All patches are from teh upstream version of ASE - this has been modified to add mpi4py
