### PR TITLE
Write spurious icon file path into Desktop file

### DIFF
--- a/easyconfigs/a/ANSYS_Rocky/ANSYS_Rocky-2024R2.0.eb
+++ b/easyconfigs/a/ANSYS_Rocky/ANSYS_Rocky-2024R2.0.eb
@@ -31,6 +31,11 @@ cmds_map = [(
 skipsteps = ['install']  # the install step deletes the directory created by the above command
 files_to_copy = []
 
+# The file rocky30.ico doesn't exist but there is a check in various scripts to ensure that it's in
+# the Rocky.desktop file and tries to write it if not, which results in an error due to user permissions
+# being insufficient in the installation directory.
+postinstallcmds = ['sed -i "/^Icon=/c\Icon=%(installdir)s/bin/rocky30.ico" %(installdir)s/Rocky.desktop']
+
 # Binaries are installed to the root of the installation, so add that root to the PATH:
 modextrapaths = {'PATH': ''}
 


### PR DESCRIPTION
For INC1559646 - `ANSYS_Rocky-2024R2.0.eb`

- Icon fix deployed manually, no rebuild required.

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

2023a and above:
* [ ] EL8-sapphire
