### PR TITLE
build(from-upstr): easyconfigs with version numbers edited

### DIFF
--- a/easyconfigs/b/Braken/Bracken-2.9-GCCcore-12.3.0.eb
+++ b/easyconfigs/b/Braken/Bracken-2.9-GCCcore-12.3.0.eb
@@ -1,0 +1,58 @@
+# Contribution from the NIHR Biomedical Research Centre
+# Guy's and St Thomas' NHS Foundation Trust and King's College London
+# uploaded by J. Sassmannshausen
+
+easyblock = 'MakeCp'
+
+name = 'Bracken'
+version = '2.9'
+
+homepage = 'https://ccb.jhu.edu/software/bracken/'
+description = """Bracken (Bayesian Reestimation of Abundance with KrakEN) 
+is a highly accurate statistical method that computes the abundance of 
+species in DNA sequences from a metagenomics sample. Braken uses the 
+taxonomy labels assigned by Kraken, a highly accurate metagenomics 
+classification algorithm, to estimate the number of reads originating 
+from each species present in a sample. Kraken classifies reads to the 
+best matching location in the taxonomic tree, but does not estimate 
+abundances of species. We use the Kraken database itself to derive 
+probabilities that describe how much sequence from each genome is 
+identical to other genomes in the database, and combine this information 
+with the assignments for a particular sample to estimate abundance at 
+the species level, the genus level, or above. Combined with the Kraken 
+classifier, Bracken produces accurate species- and genus-level abundance 
+estimates even when a sample contains two or more near-identical species.
+
+NOTE: Bracken is compatible with both Kraken 1 and Kraken 2. However, the 
+default kmer length is different depending on the version of Kraken used. 
+If you use Kraken 1 defaults, specify 31 as the kmer length. If you use 
+Kraken 2 defaults, specify 35 as the kmer length."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+toolchainopts = {'optarch': True, 'cstd': 'c++11'}
+
+github_account = 'jenniferlu717'
+#source_urls = ['https://github.com/jenniferlu717/Bracken/archive/']
+source_urls = [ GITHUB_SOURCE ]
+sources = ['v%(version)s.tar.gz']
+checksums = ['b8fd43fc396a2184d9351fb4a459f95ae9bb5865b195a18e22436f643044c788']
+
+builddependencies = [('binutils', '2.40')]
+
+# no need to build in parallel 
+parallel = 1
+
+start_dir = 'src'
+
+files_to_copy = ['bracken', 'bracken-build', 'src', 'analysis_scripts', 'sample_data']
+
+sanity_check_paths = {
+    'files': ['bracken', 'bracken-build'],
+    'dirs': ['analysis_scripts', 'sample_data', 'src'],
+}
+
+sanity_check_commands = ['bracken --help', 'bracken --version']
+
+modextrapaths = {'PATH': '.'}
+
+moduleclass = 'bio'

--- a/easyconfigs/b/Braken/Bracken-2.9-GCCcore-12.3.0.eb
+++ b/easyconfigs/b/Braken/Bracken-2.9-GCCcore-12.3.0.eb
@@ -8,38 +8,37 @@ name = 'Bracken'
 version = '2.9'
 
 homepage = 'https://ccb.jhu.edu/software/bracken/'
-description = """Bracken (Bayesian Reestimation of Abundance with KrakEN) 
-is a highly accurate statistical method that computes the abundance of 
-species in DNA sequences from a metagenomics sample. Braken uses the 
-taxonomy labels assigned by Kraken, a highly accurate metagenomics 
-classification algorithm, to estimate the number of reads originating 
-from each species present in a sample. Kraken classifies reads to the 
-best matching location in the taxonomic tree, but does not estimate 
-abundances of species. We use the Kraken database itself to derive 
-probabilities that describe how much sequence from each genome is 
-identical to other genomes in the database, and combine this information 
-with the assignments for a particular sample to estimate abundance at 
-the species level, the genus level, or above. Combined with the Kraken 
-classifier, Bracken produces accurate species- and genus-level abundance 
-estimates even when a sample contains two or more near-identical species.
+description = """Bracken (Bayesian Reestimation of Abundance with KrakEN)
+ is a highly accurate statistical method that computes the abundance of
+ species in DNA sequences from a metagenomics sample. Braken uses the
+ taxonomy labels assigned by Kraken, a highly accurate metagenomic
+ classification algorithm, to estimate the number of reads originatin
+ from each species present in a sample. Kraken classifies reads to th
+ best matching location in the taxonomic tree, but does not estimat
+ abundances of species. We use the Kraken database itself to deriv
+ probabilities that describe how much sequence from each genome i
+ identical to other genomes in the database, and combine this informatio
+ with the assignments for a particular sample to estimate abundance a
+ the species level, the genus level, or above. Combined with the Krake
+ classifier, Bracken produces accurate species- and genus-level abundanc
+ estimates even when a sample contains two or more near-identical specie
 
-NOTE: Bracken is compatible with both Kraken 1 and Kraken 2. However, the 
-default kmer length is different depending on the version of Kraken used. 
-If you use Kraken 1 defaults, specify 31 as the kmer length. If you use 
-Kraken 2 defaults, specify 35 as the kmer length."""
+ NOTE: Bracken is compatible with both Kraken 1 and Kraken 2. However, the
+ default kmer length is different depending on the version of Kraken used.
+ If you use Kraken 1 defaults, specify 31 as the kmer length. If you use
+ Kraken 2 defaults, specify 35 as the kmer length."""
 
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'optarch': True, 'cstd': 'c++11'}
 
 github_account = 'jenniferlu717'
-#source_urls = ['https://github.com/jenniferlu717/Bracken/archive/']
-source_urls = [ GITHUB_SOURCE ]
+source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
 checksums = ['b8fd43fc396a2184d9351fb4a459f95ae9bb5865b195a18e22436f643044c788']
 
 builddependencies = [('binutils', '2.40')]
 
-# no need to build in parallel 
+# no need to build in parallel
 parallel = 1
 
 start_dir = 'src'

--- a/easyconfigs/k/Kraken2/Kraken2-2.1.3-gompi-2023a.eb
+++ b/easyconfigs/k/Kraken2/Kraken2-2.1.3-gompi-2023a.eb
@@ -1,0 +1,68 @@
+easyblock = 'PackedBinary'
+
+name = 'Kraken2'
+version = '2.1.3'
+
+homepage = 'https://github.com/DerrickWood/kraken2/wiki'
+description = """Kraken is a system for assigning taxonomic labels to short DNA sequences,
+ usually obtained through metagenomic studies. Previous attempts by other
+ bioinformatics software to accomplish this task have often used sequence
+ alignment or machine learning techniques that were quite slow, leading to
+ the development of less sensitive but much faster abundance estimation
+ programs. Kraken aims to achieve high sensitivity and high speed by
+ utilizing exact alignments of k-mers and a novel classification algorithm."""
+
+# part is compiled with $CXX, the rest is in Perl
+toolchain = {'name': 'gompi', 'version': '2023a'}
+toolchainopts = {'openmp': True, 'cstd': 'c++11'}
+
+github_account = 'DerrickWood'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+patches = [
+    '%(name)s-2.1.3_fix_installation_for_easybuild.patch',
+]
+checksums = [
+    {'v2.1.3.tar.gz': '5269fa14adfb02e38c2da2e605e909a432d76c680d73e2e0e80e27ccd04d7c69'},
+    {'Kraken2-2.1.3_fix_installation_for_easybuild.patch':
+     'd2faecff258133033cb81d5ac70d1a7ff1b4323091411aa835a13de83f2cc174'},
+]
+
+dependencies = [
+    ('Perl', '5.36.1'),
+    ('BLAST+', '2.14.1'),
+    ('wget', '1.24.5'),
+]
+
+install_cmd = 'cd %(builddir)s/%(namelower)s-%(version)s && '
+install_cmd += './install_kraken2.sh %(installdir)s/bin'
+
+# Kraken2 databases can be downloaded from https://benlangmead.github.io/aws-indexes/k2
+# or built as described in https://github.com/DerrickWood/kraken2/wiki/Manual#kraken-2-databases
+# The following commands will build and install the standard databases (100GB) in local_db_path
+# local_db_path = '%(installdir)s/db'
+# postinstallcmds = [
+#     'mkdir %s' % local_db_path,
+#     'cd %%(installdir)s/bin && ./kraken2-build --standard --threads %%(parallel)s --db %s' % local_db_path,
+# ]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in [
+        '16S_gg_installation.sh', '16S_rdp_installation.sh', '16S_silva_installation.sh', 'add_to_library.sh',
+        'build_db', 'build_gg_taxonomy.pl', 'build_kraken2_db.sh', 'build_rdp_taxonomy.pl', 'build_silva_taxonomy.pl',
+        'classify', 'clean_db.sh', 'cp_into_tempfile.pl', 'download_genomic_library.sh', 'download_taxonomy.sh',
+        'dump_table', 'estimate_capacity', 'kraken2', 'kraken2-build', 'kraken2-inspect', 'kraken2lib.pm',
+        'lookup_accession_numbers.pl', 'make_seqid2taxid_map.pl', 'mask_low_complexity.sh', 'rsync_from_ncbi.pl',
+        'scan_fasta_file.pl']],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    'kraken2 --help',
+    'kraken2-build --help',
+    'kraken2-inspect --help',
+    'build_db -h',
+    'classify -h',
+]
+
+moduleclass = 'bio'

--- a/easyconfigs/k/Kraken2/Kraken2-2.1.3_fix_installation_for_easybuild.patch
+++ b/easyconfigs/k/Kraken2/Kraken2-2.1.3_fix_installation_for_easybuild.patch
@@ -1,0 +1,30 @@
+Fix install script and src/Makefile for EasyBuild.
+
+Åke Sandgren, 2021-04-30
+Update: Petr Král (INUITS)
+diff -u install_kraken2.sh.orig install_kraken2.sh
+--- install_kraken2.sh.orig     2023-06-07 02:25:37.000000000 +0200
++++ install_kraken2.sh  2024-11-12 11:34:20.122193572 +0100
+@@ -23,7 +23,9 @@
+ 
+ # Perl cmd used to canonicalize dirname - "readlink -f" doesn't work
+ # on OS X.
+-export KRAKEN2_DIR=$(perl -MCwd=abs_path -le 'print abs_path(shift)' "$1")
++# export KRAKEN2_DIR=$(perl -MCwd=abs_path -le 'print abs_path(shift)' "$1")
++
++export KRAKEN2_DIR=$1
+ 
+ mkdir -p "$KRAKEN2_DIR"
+ make -C src install
+diff -u src/Makefile.orig src/Makefile
+--- src/Makefile.orig   2023-06-07 02:25:37.000000000 +0200
++++ src/Makefile        2024-11-12 10:13:26.330138787 +0100
+@@ -1,6 +1,6 @@
+-CXX = g++
++CXX ?= g++
+ KRAKEN2_SKIP_FOPENMP ?= -fopenmp
+-CXXFLAGS = $(KRAKEN2_SKIP_FOPENMP) -Wall -std=c++11 -O3
++CXXFLAGS ?= $(KRAKEN2_SKIP_FOPENMP) -Wall -std=c++11 -O3
+ CXXFLAGS += -DLINEAR_PROBING
+ 
+ .PHONY: all clean install


### PR DESCRIPTION
For INC1579050 - 
`Bracken-2.9-GCCcore-12.3.0.eb`
`Kraken2-2.1.3-gompi-2023a.eb`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

2023a and above:
* [ ] EL8-sapphire
