### PR TITLE
code-server 4.97.2 (version bump)

### DIFF
--- a/easyconfigs/c/code-server/code-server-4.97.2.eb
+++ b/easyconfigs/c/code-server/code-server-4.97.2.eb
@@ -1,0 +1,13 @@
+name = 'code-server'
+version = '4.97.2'
+
+homepage = 'https://github.com/coder/code-server'
+description = """Run VS Code on any machine anywhere and access it in the browser."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/coder/code-server/releases/download/v%(version)s/']
+sources = ['code-server-%(version)s-linux-%(mapped_arch)s.tar.gz']
+checksums = ['c7d5e389be56e54d300ef60610a4c877fe54cf62f0df4bb6fc2e3f04618009eb']
+
+moduleclass = 'tools'


### PR DESCRIPTION
For BEAR Portal updates - `code-server-4.97.2.eb`

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake

2023a and above:
* [ ] EL8-sapphire
