### PR TITLE
DualSPHysics 5.2.269

### DIFF
--- a/easyconfigs/d/DualSPHysics/DualSPHysics-5.2.269-foss-2023a-CUDA-12.1.1.eb
+++ b/easyconfigs/d/DualSPHysics/DualSPHysics-5.2.269-foss-2023a-CUDA-12.1.1.eb
@@ -1,0 +1,64 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'MakeCp'
+
+name = 'DualSPHysics'
+version = '5.2.269'
+versionsuffix = '-CUDA-%(cudaver)s'
+local_commit_id = '8ad979c'
+
+homepage = "https://dual.sphysics.org"
+description = """DualSPHysics is based on the Smoothed Particle Hydrodynamics model named SPHysics (www.sphysics.org).
+ The code is developed (GNU Lesser General Public License) to study free-surface flow phenomena where Eulerian methods
+ can be difficult to apply. DualSPHysics is a set of C++, CUDA and Java codes designed to deal with real-life
+ engineering problems."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+source_urls = ['https://github.com/DualSPHysics/DualSPHysics/archive']
+sources = ['%s.tar.gz' % local_commit_id]
+patches = ['%(name)s-%(version)s_makefiles.patch']
+checksums = [
+    {'8ad979c.tar.gz': '46976c91b370474efff96e0149b74d45a678912c013aeb6c837ed7a0d14627de'},
+    {'DualSPHysics-5.2.269_makefiles.patch': 'b93c32f6c8c1afc7b979dd298b1cd31e24c79f48c7790e466f84a451a7622984'},
+]
+
+dependencies = [
+    ('Java', '11', '', True),
+    ('CUDA', '12.1.1', '', True),
+]
+
+cuda_compute_capabilities = ['8.0', '9.0']
+# replace CUDA compute capabilities in Makefiles
+_replacement_string = ''
+
+for i in range(len(cuda_compute_capabilities)):
+    _c = cuda_compute_capabilities[i].replace('.', '')
+    _replacement_string += (r'GENCODE:=\$\(GENCODE\) \-gencode=arch=compute_%s,code=\\"sm_%s,compute_%s\\"\n'
+                            % (_c, _c, _c))
+
+_replacement_cmd = "sed -i 's/^GENCODE.*/%s/' Makefile" % _replacement_string
+
+build_cmd = 'cd src/source && '
+build_cmd += '%s && ' % _replacement_cmd
+build_cmd += 'make -j %(parallel)s && '
+build_cmd += 'cd ../../src_mphase/DSPH_v5.0_NNewtonian/source && '
+build_cmd += '%s && ' % _replacement_cmd
+build_cmd += 'make'
+
+postinstallcmds = ['chmod 755 %(installdir)s/bin/*']
+
+files_to_copy = [
+    (['bin/linux/*_linux64'], 'bin'),
+    (['src/lib/linux_gcc/lib*'], 'lib'),
+    'LICENSE', 'README.md', 'doc', 'examples',
+]
+
+sanity_check_paths = {
+    'files': [
+        ['bin/%%(name)s5.0%s' % x for x in ['_linux64', '_NNewtonian_linux64']],
+        ['lib/%s' % x for x in ['libChronoEngine.%s' % SHLIB_EXT, 'libdsphchrono.%s' % SHLIB_EXT]]
+    ],
+    'dirs': ['examples']
+}
+
+moduleclass = 'phys'

--- a/easyconfigs/d/DualSPHysics/DualSPHysics-5.2.269-foss-2023a.eb
+++ b/easyconfigs/d/DualSPHysics/DualSPHysics-5.2.269-foss-2023a.eb
@@ -1,0 +1,47 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'MakeCp'
+
+name = 'DualSPHysics'
+version = '5.2.269'
+local_commit_id = '8ad979c'
+
+homepage = "https://dual.sphysics.org"
+description = """DualSPHysics is based on the Smoothed Particle Hydrodynamics model named SPHysics (www.sphysics.org).
+ The code is developed (GNU Lesser General Public License) to study free-surface flow phenomena where Eulerian methods
+ can be difficult to apply. DualSPHysics is a set of C++, CUDA and Java codes designed to deal with real-life
+ engineering problems."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+source_urls = ['https://github.com/DualSPHysics/DualSPHysics/archive']
+sources = ['%s.tar.gz' % local_commit_id]
+patches = ['%(name)s-%(version)s_makefiles.patch']
+checksums = [
+    {'8ad979c.tar.gz': '46976c91b370474efff96e0149b74d45a678912c013aeb6c837ed7a0d14627de'},
+    {'DualSPHysics-5.2.269_makefiles.patch': 'b93c32f6c8c1afc7b979dd298b1cd31e24c79f48c7790e466f84a451a7622984'},
+]
+
+dependencies = [
+    ('Java', '11', '', True),
+]
+
+build_cmd = 'cd src/source && make -f Makefile_cpu -j %(parallel)s && '
+build_cmd += 'cd ../../src_mphase/DSPH_v5.0_NNewtonian/source && make -f Makefile_cpu'
+
+postinstallcmds = ['chmod 755 %(installdir)s/bin/*']
+
+files_to_copy = [
+    (['bin/linux/*_linux64'], 'bin'),
+    (['src/lib/linux_gcc/lib*'], 'lib'),
+    'LICENSE', 'README.md', 'doc', 'examples',
+]
+
+sanity_check_paths = {
+    'files': [
+        ['bin/%%(name)s5.0%s' % x for x in ['CPU_linux64', '_NNewtonianCPU_linux64']],
+        ['lib/%s' % x for x in ['libChronoEngine.%s' % SHLIB_EXT, 'libdsphchrono.%s' % SHLIB_EXT]]
+    ],
+    'dirs': ['examples']
+}
+
+moduleclass = 'phys'

--- a/easyconfigs/d/DualSPHysics/DualSPHysics-5.2.269_makefiles.patch
+++ b/easyconfigs/d/DualSPHysics/DualSPHysics-5.2.269_makefiles.patch
@@ -1,0 +1,198 @@
+diff -Nru DualSPHysics-5.0.233.orig/src/source/Makefile DualSPHysics-5.0.233/src/source/Makefile
+--- DualSPHysics-5.0.233.orig/src/source/Makefile.orig	2025-03-06 11:47:23.241151528 +0000
++++ DualSPHysics-5.0.233/src/source/Makefile	2025-03-06 11:51:33.241013017 +0000
+@@ -3,7 +3,7 @@
+ #=============== Compilation Options (YES/NO) ===============
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -47,65 +47,11 @@
+   CCFLAGS:=$(CCFLAGS) -DDISABLE_MOORDYN
+ endif
+ 
+-#=============== CUDA selection ===============
+-CUDAVER=11
+-
+ #=============== CUDA toolkit directory (make appropriate for local CUDA installation) ===============
+-ifeq ($(CUDAVER),00)
+-  DIRTOOLKIT=/usr/local/cuda
+-endif
+-ifeq ($(CUDAVER),75)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-7.5
+-endif
+-ifeq ($(CUDAVER),91)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-9.1
+-endif
+-ifeq ($(CUDAVER),92)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-9.2
+-endif
+-ifeq ($(CUDAVER),11)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-11.7
+-endif
++DIRTOOLKIT=$(EBROOTCUDA)
+ 
+ #=============== Select GPU architectures ===============
+-ifeq ($(CUDAVER),00)
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_20,code=\"sm_20,compute_20\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-endif
+-ifeq ($(CUDAVER),75)
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_20,code=\"sm_20,compute_20\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_37,code=\"sm_37,compute_37\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-endif
+-ifeq ($(CUDAVER),91)
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+-endif
+-ifeq ($(CUDAVER),92)
+-  # module load cuda/9.2
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+-endif
+-ifeq ($(CUDAVER),11)
+-  # module load cuda/11.7
+-  # GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+-endif
++GENCODE:=stub_to_replace_via_easyconfig
+ 
+ #=============== Files to compile ===============
+ OBJXML=JXml.o tinystr.o tinyxml.o tinyxmlerror.o tinyxmlparser.o
+diff -Nru DualSPHysics-5.0.233.orig/src/source/Makefile_cpu DualSPHysics-5.0.233/src/source/Makefile_cpu
+--- DualSPHysics-5.0.233.orig/src/source/Makefile_cpu	2023-07-13 23:36:10.405708181 +0100
++++ DualSPHysics-5.0.233/src/source/Makefile_cpu	2023-07-13 23:37:46.419298390 +0100
+@@ -4,7 +4,7 @@
+ USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+diff -Nru DualSPHysics-5.0.233.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile DualSPHysics-5.0.233/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile
+--- DualSPHysics-5.0.233.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile	2023-07-13 23:36:11.729366000 +0100
++++ DualSPHysics-5.0.233/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile	2023-07-14 17:36:46.233911536 +0100
+@@ -1,10 +1,10 @@
+ #DualSPHysics NNewtonian GPU/CPU v5.0.164 21-11-2020
+ 
+ #=============== Compilation Options (YES/NO) ===============
+-USE_GCC5=NO
++USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -15,7 +15,7 @@
+ LIBS_DIRECTORIES:=$(LIBS_DIRECTORIES) -L../lib/linux_gcc
+ 
+ EXECNAME=DualSPHysics5.0_NNewtonian_linux64
+-EXECS_DIRECTORY=../../../bin/linux/DSNNewtonian
++EXECS_DIRECTORY=../../../bin/linux
+ 
+ # -std=c++0x ---> Used to avoid errors for calls to enums
+ ifeq ($(USE_DEBUG), YES)
+@@ -55,53 +55,11 @@
+   CCFLAGS:=$(CCFLAGS) -DDISABLE_MOORDYN
+ endif
+ 
+-#=============== CUDA selection ===============
+-CUDAVER=92
+-
+ #=============== CUDA toolkit directory (make appropriate for local CUDA installation) ===============
+-ifeq ($(CUDAVER),00)
+-  DIRTOOLKIT=/usr/local/cuda
+-endif
+-ifeq ($(CUDAVER),75)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-7.5
+-endif
+-ifeq ($(CUDAVER),91)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-9.1
+-endif
+-ifeq ($(CUDAVER),92)
+-  DIRTOOLKIT=/exports/opt/NVIDIA/cuda-9.2
+-endif
++DIRTOOLKIT=$(EBROOTCUDA)
+ 
+ #=============== Select GPU architectures ===============
+-ifeq ($(CUDAVER),00)
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_20,code=\"sm_20,compute_20\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-endif
+-ifeq ($(CUDAVER),75)
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_20,code=\"sm_20,compute_20\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_37,code=\"sm_37,compute_37\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-endif
+-ifeq ($(CUDAVER),91)
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+-endif
+-ifeq ($(CUDAVER),92)
+-  # module load cuda/9.2
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_30,code=\"sm_30,compute_30\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_35,code=\"sm_35,compute_35\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_50,code=\"sm_50,compute_50\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+-  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+-endif
++GENCODE:=stub_to_replace_via_easyconfig
+ 
+ 
+ #=============== Files to compile ===============
+diff -Nru DualSPHysics-5.0.233.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu DualSPHysics-5.0.233/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu
+--- DualSPHysics-5.0.233.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu	2023-07-13 23:36:11.731310855 +0100
++++ DualSPHysics-5.0.233/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu	2023-07-14 09:45:26.879917402 +0100
+@@ -1,10 +1,10 @@
+ #DualSPHysics NNewtonian CPU v5.0.164 21-11-2020
+ 
+ #=============== Compilation Options (YES/NO) ===============
+-USE_GCC5=NO
++USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -15,7 +15,7 @@
+ LIBS_DIRECTORIES:=$(LIBS_DIRECTORIES) -L../lib/linux_gcc
+ 
+ EXECNAME=DualSPHysics5.0_NNewtonianCPU_linux64
+-EXECS_DIRECTORY=../../../bin/linux/DSNNewtonian
++EXECS_DIRECTORY=../../../bin/linux
+ 
+ # -std=c++0x ---> Used to avoid errors for calls to enums
+ ifeq ($(USE_DEBUG), YES)


### PR DESCRIPTION
For INC1582872

N.B. developer has stopped tagging releases in GitHub so this uses the short commit hash for the download instead. See the following link for reference, linking this commit to version  `5.2.269`.
<https://github.com/DualSPHysics/DualSPHysics/commit/fc8290c703ed79a341089062d04abd2e16c82e4e#diff-49d51a651d8a7123e5101becf3d019a73155dc8dfe6b38fe20a4305eb39bfe27R39>

* [x] Assigned to reviewer

`DualSPHysics-5.2.269-foss-2023a.eb`

* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-sapphire

`DualSPHysics-5.2.269-foss-2023a-CUDA-12.1.1.eb`

* [ ] EL8-icelake
