### PR TITLE
CST 2025.SP3

### DIFF
--- a/easyconfigs/c/CST-Studio-Suite/CST-Studio-Suite-2025.SP3-GCCcore-12.3.0-Java-17.eb
+++ b/easyconfigs/c/CST-Studio-Suite/CST-Studio-Suite-2025.SP3-GCCcore-12.3.0-Java-17.eb
@@ -30,6 +30,11 @@ dependencies = [
     ('Xvfb', '21.1.8'),
 ]
 
+postinstallcmds = [
+    'cd %(installdir)s/LinuxAMD64 && '
+    'sed -i \'s/"${CST_REGSVR32}" -c -s "${CST_OCX}"/"${CST_REGSVR32}" "${CST_OCX}"/\' {modeler,schematic}_AMD64'
+]
+
 license_server = 'eee-cst-ce.bham.ac.uk'
 license_server_port = '27004'
 sp_level = '%(version_minor)s'

--- a/easyconfigs/c/CST-Studio-Suite/CST-Studio-Suite-2025.SP3-GCCcore-12.3.0-Java-17.eb
+++ b/easyconfigs/c/CST-Studio-Suite/CST-Studio-Suite-2025.SP3-GCCcore-12.3.0-Java-17.eb
@@ -1,0 +1,40 @@
+easyblock = 'EB_CST'
+
+name = 'CST-Studio-Suite'
+version = '2025.SP3'
+versionsuffix = '-Java-17'
+
+homepage = 'https://www.3ds.com/products-services/simulia/products/cst-studio-suite/'
+description = """CST Studio Suite is a high-performance 3D EM analysis software package for designing, analyzing and
+ optimizing electromagnetic (EM) components and systems."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+sources = [
+    'CST_S2_2025/CST_S2_2025.CST_S2_2025.SIMULIA_CST_Studio_Suite.Linux64.tar',
+    'CST_S2_2025/CST_S2_2025_SP3.SPK_SIMULIA_CST_Studio_Suite.Linux64.tar.gz',
+]
+checksums = [
+    {'CST_S2_2025.CST_S2_2025.SIMULIA_CST_Studio_Suite.Linux64.tar':
+     'f608aebd9b4d097ee2e8821f6d4a07e57d0be0ea57fc080a209a9089f9aabff9'},
+    {'CST_S2_2025_SP3.SPK_SIMULIA_CST_Studio_Suite.Linux64.tar.gz':
+     '42bf834430e288689282e8c0534539f256e95265d141cf064699b9cdc863c2a5'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+dependencies = [
+    ('Java', '17', '', SYSTEM),
+    ('motif', '2.3.8'),
+    ('Xvfb', '21.1.8'),
+]
+
+license_server = 'eee-cst-ce.bham.ac.uk'
+license_server_port = '27004'
+sp_level = '%(version_minor)s'
+extract_sources = True
+
+modextravars = {'CST_FORCE_SOFTWARE_RENDERER': '1'}
+
+moduleclass = 'cae'


### PR DESCRIPTION
For INC1589349 - `CST-Studio-Suite-2025.SP3-GCCcore-12.3.0-Java-17.eb`

Includes fix recommended by CST support to resolve the `$CST_REGSVR32` core-dump issue

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
