### PR TITLE
folium timm einops pystac_client stackstac

### DIFF
--- a/easyconfigs/e/einops/einops-0.8.1-gfbf-2023a.eb
+++ b/easyconfigs/e/einops/einops-0.8.1-gfbf-2023a.eb
@@ -1,0 +1,50 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonPackage'
+
+name = 'einops'
+version = '0.8.1'
+
+homepage = "https://einops.rocks"
+description = """Flexible and powerful tensor operations for readable and reliable code.
+ Supports numpy, pytorch, tensorflow, jax, and others."""
+
+citing = """
+@inproceedings{
+    rogozhnikov2022einops,
+    title={Einops: Clear and Reliable Tensor Manipulations with Einstein-like Notation},
+    author={Alex Rogozhnikov},
+    booktitle={International Conference on Learning Representations},
+    year={2022},
+    url={https://openreview.net/forum?id=oapKSVM2bcj}
+}
+"""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+builddependencies = [
+    # ('binutils', '2.40'),
+    ('hatchling', '1.18.0'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+]
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84']
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    'python -c "import einops; print(einops.__version__)"'
+]
+
+moduleclass = 'math'

--- a/easyconfigs/e/einops/einops-0.8.1-gfbf-2023a.eb
+++ b/easyconfigs/e/einops/einops-0.8.1-gfbf-2023a.eb
@@ -22,7 +22,6 @@ citing = """
 toolchain = {'name': 'gfbf', 'version': '2023a'}
 
 builddependencies = [
-    # ('binutils', '2.40'),
     ('hatchling', '1.18.0'),
 ]
 

--- a/easyconfigs/f/folium/folium-0.19.5-gfbf-2023a.eb
+++ b/easyconfigs/f/folium/folium-0.19.5-gfbf-2023a.eb
@@ -1,0 +1,39 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'folium'
+version = '0.19.5'
+
+homepage = "https://github.com/python-visualization/folium"
+description = """folium builds on the data wrangling strengths of the Python ecosystem
+ and the mapping strengths of the Leaflet.js library. Manipulate your data in Python,
+ then visualize it in a Leaflet map via folium."""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
+    ('SciPy-bundle', '2023.07'),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('branca', '0.8.1', {
+        'checksums': ['ac397c2d79bd13af0d04193b26d5ed17031d27609a7f1fab50c438b8ae712390'],
+    }),
+    ('xyzservices', '2025.1.0', {
+        'checksums': ['5cdbb0907c20be1be066c6e2dc69c645842d1113a4e83e642065604a21f254ba'],
+    }),
+    (name, version, {
+        'checksums': ['103ef92d7738b91972f4531211f76eee3f38c88be03111bbd6a5e65c69d084df'],
+    }),
+]
+
+moduleclass = 'vis'

--- a/easyconfigs/h/hatch-nodejs-version/hatch-nodejs-version-0.3.2-GCCcore-12.3.0.eb
+++ b/easyconfigs/h/hatch-nodejs-version/hatch-nodejs-version-0.3.2-GCCcore-12.3.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = 'hatch-nodejs-version'
+version = '0.3.2'
+
+homepage = 'https://github.com/agoose77/hatch-nodejs-version'
+description = """
+  This package provides two Hatch plugins:
+  * version source plugin
+  * metadata hook plugin
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('hatchling', '1.18.0'),
+]
+
+sources = ['hatch_nodejs_version-0.3.2.tar.gz']
+checksums = ['8a7828d817b71e50bbbbb01c9bfc0b329657b7900c56846489b9c958de15b54c']
+
+sanity_pip_check = True
+use_pip = True
+download_dep_fail = True
+
+moduleclass = 'devel'

--- a/easyconfigs/p/pystac-client/pystac-client-0.8.6-gfbf-2023a.eb
+++ b/easyconfigs/p/pystac-client/pystac-client-0.8.6-gfbf-2023a.eb
@@ -1,0 +1,54 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'pystac-client'
+version = '0.8.6'
+
+homepage = "https://github.com/stac-utils/pystac-client"
+description = """A Python client for working with STAC APIs."""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+builddependencies = [
+    ('hatchling', '1.18.0'),  # for jsonschema
+    ('maturin', '1.4.0', '-Rust-1.75.0'),  # for rpds_py
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('rpds_py', '0.17.1', {
+        'modulename': 'rpds',
+        'checksums': ['0210b2668f24c078307260bf88bdac9d6f1093635df5123789bfee4d8d7fc8e7'],
+    }),
+    ('referencing', '0.32.1', {
+        'checksums': ['3c57da0513e9563eb7e203ebe9bb3a1b509b042016433bd1e45a2853466c3dd3'],
+    }),
+    ('jsonschema_specifications', '2023.12.1', {
+        'checksums': ['48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc'],
+    }),
+    #  we need a newer version of jsonschema than included in P-b-P 2023.06
+    ('jsonschema', '4.18.4', {
+        'checksums': ['fb3642735399fa958c0d2aad7057901554596c63349f4f6b283c493cf692a25d'],
+    }),
+    #  we use 1.11.0 due to unsupported trove classifier in >1.11.0
+    ('pystac', '1.11.0', {
+        'use_pip_extras': 'validation',
+        'checksums': ['acb1e04be398a0cda2d8870ab5e90457783a8014a206590233171d8b2ae0d9e7'],
+    }),
+    ('pystac_client', version, {
+        'checksums': ['83d4f4420c14b8dbb3e39ab0da00e72639903912942075d42e06737d61ab3e7d'],
+    }),
+]
+
+moduleclass = 'lib'

--- a/easyconfigs/s/StackSTAC/StackSTAC-0.5.1-foss-2023a.eb
+++ b/easyconfigs/s/StackSTAC/StackSTAC-0.5.1-foss-2023a.eb
@@ -1,0 +1,83 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'StackSTAC'
+version = '0.5.1'
+
+homepage = "https://stackstac.readthedocs.io/en/latest/index.html"
+description = """Turn a list of STAC items into a 4D xarray DataArray (dims: time, band, y, x),
+ including reprojection to a common grid. The array is a lazy Dask array, so loading and
+ processing the data in parallel—locally or on a cluster—is just a compute() call away."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+builddependencies = [
+    ('PDM', '2.12.4'),
+    ('hatchling', '1.18.0'),
+    ('hatch-nodejs-version', '0.3.2'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
+    ('SciPy-bundle', '2023.07'),
+    ('xarray', '2023.9.0'),
+    ('dask', '2023.9.2'),
+    ('rasterio', '1.3.9'),
+    ('pyproj', '3.6.0'),
+    ('Pillow', '10.0.0'),
+    ('aiohttp', '3.8.5'),
+    ('matplotlib', '3.7.2'),
+    ('nodejs', '18.17.1'),
+    ('JupyterLab', '4.0.5'),
+    ('jupyter-server-proxy', '4.0.0'),
+    ('JupyterNotebook', '7.0.2'),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('jupyterlab_widgets', '3.0.9', {
+        'checksums': ['6005a4e974c7beee84060fdfba341a3218495046de8ae3ec64888e5fe19fdb4c'],
+    }),
+    ('widgetsnbextension', '4.0.9', {
+        'checksums': ['3c1f5e46dc1166dfd40a42d685e6a51396fd34ff878742a3e47c6f0cc4a2a385'],
+    }),
+    ('ipywidgets', '8.1.1', {
+        'checksums': ['40211efb556adec6fa450ccc2a77d59ca44a060f4f9f136833df59c9f538e6e8'],
+    }),
+    ('jupyter_leaflet', '0.19.2', {
+        'checksums': ['b09b5ba48b1488cb61da37a6f558347269eb53ff6d64dc1a73e005ffc4420063'],
+    }),
+    ('traittypes', '0.2.1', {
+        'checksums': ['be6fa26294733e7489822ded4ae25da5b4824a8a7a0e0c2dccfde596e3489bd6'],
+    }),
+    ('branca', '0.8.1', {
+        'checksums': ['ac397c2d79bd13af0d04193b26d5ed17031d27609a7f1fab50c438b8ae712390'],
+    }),
+    ('ipyleaflet', '0.19.2', {
+        'checksums': ['b3b83fe3460e742964c2a5924ea7934365a3749bb75310ce388d45fd751372d2'],
+    }),
+    ('mercantile', '1.2.1', {
+        'checksums': ['fa3c6db15daffd58454ac198b31887519a19caccee3f9d63d17ae7ff61b3b56b'],
+    }),
+    ('cachetools', '4.2.4', {
+        'checksums': ['89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693'],
+    }),
+    ('stackstac', version, {
+        'patches': ['StackSTAC-0.5.1_use_pdm_backend.patch'],
+        'use_pip_extras': 'extra',
+        'checksums': [
+            {'stackstac-0.5.1.tar.gz': '1af0e1251100fe506b1f3c035ffcc34111ad67b264275d14a6775c4991e5f7f6'},
+            {'StackSTAC-0.5.1_use_pdm_backend.patch':
+             '5717b62dfe9fe879019d106104a2427ab4a5c39f97d136dab83f2336a4b778ca'},
+        ],
+    }),
+]
+
+moduleclass = 'data'

--- a/easyconfigs/s/StackSTAC/StackSTAC-0.5.1_use_pdm_backend.patch
+++ b/easyconfigs/s/StackSTAC/StackSTAC-0.5.1_use_pdm_backend.patch
@@ -1,0 +1,12 @@
+--- stackstac-0.5.1.orig/pyproject.toml	2025-04-02 13:44:09.453523604 +0100
++++ stackstac-0.5.1/pyproject.toml	2025-04-02 13:44:38.833376392 +0100
+@@ -80,7 +80,7 @@
+ ]
+ 
+ [build-system]
+-build-backend = "pdm.pep517.api"
++build-backend = "pdm.backend"
+ requires = [
+-    "pdm-pep517",
++    "pdm-backend",
+ ]

--- a/easyconfigs/t/timm/timm-1.0.8-foss-2023a.eb
+++ b/easyconfigs/t/timm/timm-1.0.8-foss-2023a.eb
@@ -1,0 +1,42 @@
+easyblock = 'PythonBundle'
+
+name = 'timm'
+version = '1.0.8'
+
+homepage = 'https://huggingface.co/docs/timm'
+description = """
+timm is a library containing SOTA computer vision models, layers, utilities,
+optimizers, schedulers, data-loaders, augmentations, and training/evaluation
+scripts.  It comes packaged with >700 pretrained models, and is designed to be
+flexible and easy to use.
+"""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('PyTorch', '2.1.2'),
+    ('PyYAML', '6.0'),
+    ('tqdm', '4.66.1'),
+    ('torchvision', '0.16.0'),
+    ('Safetensors', '0.4.3'),
+]
+
+builddependencies = [
+    ('PDM', '2.12.4'),
+]
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+exts_list = [
+    ('huggingface_hub', '0.24.5', {
+        'checksums': ['7b45d6744dd53ce9cbf9880957de00e9d10a9ae837f1c9b7255fc8fa4e8264f3'],
+    }),
+    (name, version, {
+        'checksums': ['f54a579f1cc39c43d99a4b03603e39c4cee87d4f0a08aba9c22e19064b30bf95'],
+    }),
+]
+
+moduleclass = 'lib'


### PR DESCRIPTION
For INC1590792 

1. `einops-0.8.1-gfbf-2023a.eb` -- there is an upstream einops for 2023a but this version is newer and I don't know why the upstream needs `binutils`
2. `folium-0.19.5-gfbf-2023a.eb` -- new easyconfig
3. `timm-1.0.8-foss-2023a.eb` -- upstream but in 5.0. This is modified for 4.9.4
4. `pystac-client-0.8.6-gfbf-2023a.eb` -- new easyconfig
5. `StackSTAC-0.5.1-foss-2023a.eb` -- new easyconfig. I've tried to only use the bare minimum of jupyterlab, so didn't use the jupyterbundle as I only need 2 or 3 of the components in it.

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
