### PR TITLE
adding --check-contrib to repo workflow

### DIFF
--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -34,6 +34,7 @@ jobs:
           sudo apt install -y ./lmod_${LMOD_VERSION}_all.deb
 
       - name: check-contrib modified .ebs only
+      #  this is too broad and runs this action on any change, rather than just eb
         run: |
           CHANGED_EBS=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.eb$' || true)
           for file in $CHANGED_EBS; do

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
+        #  with:
+        #      fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
       - name: Set up Python env
         uses: actions/setup-python@v5
@@ -22,12 +24,18 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      - name: Install EasyBuild and pycodestyle  # needed for check-contrib
-        run: pip install easybuild==4.9.4 pycodestyle
-
-      - name: Run check-contrib
+      - name: Install EasyBuild and required deps
         run: |
-          for file in $(find . -name '*.eb'); do
-            echo "Checking $file"
+          pip install easybuild==4.9.4 pycodestyle
+          sudo apt-get install -y lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
+          sudo apt install -y curl
+          LMOD_VERSION=8.7.4
+          curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb
+          sudo apt install -y ./lmod_${LMOD_VERSION}_all.deb
+
+      - name: check-contrib modified .ebs only
+        run: |
+          CHANGED_EBS=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.eb$' || true)
+          for file in $CHANGED_EBS; do
             eb "$file" --check-contrib
           done

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2  # shallow but deep enough to diff last commit
+          fetch-depth: 2  # shallow but deep enough to diff last commit; I don't want to have do to fetch-depth: 0 and get the full history
 
       - name: Set up Python env
         uses: actions/setup-python@v5
@@ -26,12 +26,25 @@ jobs:
 
       - name: Install EasyBuild and required deps
         run: |
+          echo "Installing easybuild and pycodestyle"
           pip install easybuild==4.9.4 pycodestyle
+
+          echo "Installing LMOD"
           sudo apt-get install -y lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
           sudo apt install -y curl
           LMOD_VERSION=8.7.4
           curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb
           sudo apt install -y ./lmod_${LMOD_VERSION}_all.deb
+
+          #  default install location via sudo apt goes to /usr/lmod
+          export PATH="/usr/lmod/$LMOD_VERSION/libexec:$PATH"
+          export MOD_INIT="/usr/lmod/$LMOD_VERSION/init/bash"
+          echo $MOD_INIT > mod_init; echo $PATH > path
+          source $(cat $HOME/mod_init); type module
+          export EASYBUILD_MODULES_TOOL=Lmod
+
+          # Verify LMOD install
+          which lmod ; lmod --version
 
       - name: Run --check-contrib
         env:
@@ -51,6 +64,9 @@ jobs:
 
           echo "Files to check:"
           printf '%s\n' "$CHANGED_EBS"
+
+          # check eb is available
+          eb --version; eb --show-config
 
           for file in $CHANGED_EBS; do
             echo "Checking $file"

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -23,7 +23,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install EasyBuild and pycodestyle  # needed for check-contrib
-        run: pip install easybuild pycodestyle
+        run: pip install easybuild==4.9.4 pycodestyle
 
       - name: Run check-contrib
         run: |

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -39,8 +39,10 @@ jobs:
           #  default install location via sudo apt goes to /usr/lmod
           export PATH="/usr/lmod/$LMOD_VERSION/libexec:$PATH"
           export MOD_INIT="/usr/lmod/$LMOD_VERSION/init/bash"
-          echo $MOD_INIT > mod_init; echo $PATH > path
-          source $(cat $HOME/mod_init); type module
+
+          echo $MOD_INIT > "$GITHUB_WORKSPACE/mod_init"
+          echo $PATH > "$GITHUB_WORKSPACE/path"
+          source $(cat "$GITHUB_WORKSPACE/mod_init") ; type module
           export EASYBUILD_MODULES_TOOL=Lmod
 
           # Verify LMOD install

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
-        #  with:
-        #      fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+        with:
+          fetch-depth: 2  # shallow but deep enough to diff last commit
 
       - name: Set up Python env
         uses: actions/setup-python@v5
@@ -33,10 +33,26 @@ jobs:
           curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb
           sudo apt install -y ./lmod_${LMOD_VERSION}_all.deb
 
-      - name: check-contrib modified .ebs only
-      #  this is too broad and runs this action on any change, rather than just eb
+      - name: Run --check-contrib
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
-          CHANGED_EBS=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.eb$' || true)
+          echo "Fetching prior commit for diff"
+          git fetch origin "$BEFORE_SHA"
+
+          echo "Checking for modified .eb files"
+          CHANGED_EBS=$(git diff --name-only --diff-filter=d "$BEFORE_SHA" "$AFTER_SHA" -- '*.eb' || echo "")
+
+          if [ -z "$CHANGED_EBS" ]; then
+            echo "No .eb files changed. Skipping check-contrib."
+            exit 0
+          fi
+
+          echo "Files to check:"
+          printf '%s\n' "$CHANGED_EBS"
+
           for file in $CHANGED_EBS; do
-            eb "$file" --check-contrib
+            echo "Checking $file"
+            eb "$file" --check-contrib || exit 1  # Fail fast on errors
           done

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -52,7 +52,14 @@ jobs:
         env:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
+          LMOD_VERSION: 8.7.4
+          MOD_INIT: "/usr/lmod/$LMOD_VERSION/init/bash"
+
         run: |
+          export PATH="/usr/lmod/$LMOD_VERSION/libexec:$PATH"
+          echo $MOD_INIT > "$GITHUB_WORKSPACE/mod_init"
+          echo $PATH > "$GITHUB_WORKSPACE/path"
+
           echo "Fetching prior commit for diff"
           git fetch origin "$BEFORE_SHA"
 

--- a/.github/workflows/check-contrib.yml
+++ b/.github/workflows/check-contrib.yml
@@ -1,0 +1,33 @@
+name: check-contrib
+
+on: [push, pull_request]  # would you need to define PRs containing .eb files?
+
+permissions:
+  contents: read  # to fetch code (actions/checkout)
+
+jobs:
+  check-contrib:
+    name: Run EasyBuild check-contrib
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python env
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install EasyBuild and pycodestyle  # needed for check-contrib
+        run: pip install easybuild pycodestyle
+
+      - name: Run check-contrib
+        run: |
+          for file in $(find . -name '*.eb'); do
+            echo "Checking $file"
+            eb "$file" --check-contrib
+          done

--- a/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
+++ b/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
@@ -1,0 +1,33 @@
+name = 'pybind11'
+version = '2.12.0'
+
+homepage = 'https://pybind11.readthedocs.io'
+description = """pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa,
+ mainly to create Python bindings of existing C++ code."""
+
+toolchain = {'name': 'GCC', 'version': '12.3.0'}
+
+source_urls = ['https://github.com/pybind/pybind11/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    'pybind11-2.10.3_require-catch.patch',
+]
+checksums = [
+    {'v2.12.0.tar.gz': 'bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7'},
+    {'pybind11-2.10.3_require-catch.patch': '4a27ba3ef1d5c535d120d6178a6e876ae678e4899a07500aab37908357b0b60b'},
+]
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+    # Test dependencies
+    ('Eigen', '3.4.0'),
+    ('Catch2', '2.13.9'),
+    ('Python-bundle-PyPI', '2023.06'),  # to provide pytest
+]
+
+dependencies = [
+    ('Boost', '1.82.0'),
+    ('Python', '3.11.3'),
+]
+
+moduleclass = 'lib'

--- a/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
+++ b/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
@@ -19,7 +19,7 @@ checksums = [
 
 builddependencies = [
     ('CMake', '3.26.3'),
-    # Test dependencies - bla bla
+    # Test dependencies - bla bla # 1441, 1804, add another line to test check-contrib
     ('Eigen', '3.4.0'),
     ('Catch2', '2.13.9'),
     ('Python-bundle-PyPI', '2023.06'),  # to provide pytest

--- a/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
+++ b/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
@@ -21,7 +21,7 @@ builddependencies = [
     ('CMake', '3.26.3'),
     # Test dependencies - bla bla # 1441, 1804, add another line to test check-contrib
     ('Eigen', '3.4.0'),  # 1542, 1804, add another line to test check-contrib
-    ('Catch2', '2.13.9'),
+    ('Catch2', '2.13.9'),# 1550, 1804, add another line to test check-contrib
     ('Python-bundle-PyPI', '2023.06'),  # to provide pytest
 ]
 

--- a/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
+++ b/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
@@ -20,7 +20,7 @@ checksums = [
 builddependencies = [
     ('CMake', '3.26.3'),
     # Test dependencies - bla bla # 1441, 1804, add another line to test check-contrib
-    ('Eigen', '3.4.0'),
+    ('Eigen', '3.4.0'),  # 1542, 1804, add another line to test check-contrib
     ('Catch2', '2.13.9'),
     ('Python-bundle-PyPI', '2023.06'),  # to provide pytest
 ]

--- a/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
+++ b/easyconfigs/p/pybind11/pybind11-2.12.0-GCC-12.3.0.eb
@@ -19,7 +19,7 @@ checksums = [
 
 builddependencies = [
     ('CMake', '3.26.3'),
-    # Test dependencies
+    # Test dependencies - bla bla
     ('Eigen', '3.4.0'),
     ('Catch2', '2.13.9'),
     ('Python-bundle-PyPI', '2023.06'),  # to provide pytest


### PR DESCRIPTION
the idea is to get `eb --check-contrib` to run on new PRs and push actions to the repo. 

This is a rough draft. Some things to work on and test more:

* Are PRs and pushes the correct gh action to apply this to?
* Does this capture the right depth of commit history
* Is this the correct behaviour we want from the CI?