### PR TITLE
rpy2-3.5.17 easyconf

### DIFF
--- a/easyconfigs/r/rpy2/rpy2-3.5.17-foss-2023a.eb
+++ b/easyconfigs/r/rpy2/rpy2-3.5.17-foss-2023a.eb
@@ -1,0 +1,43 @@
+# Author: Pavel Grochal (INUITS)
+# Updated: Denis Kristak, Pavel Tománek (INUITS)
+# License: GPLv2
+
+easyblock = 'PythonBundle'
+
+name = 'rpy2'
+version = '3.5.17'
+
+homepage = 'https://rpy2.github.io'
+description = """rpy2 is an interface to R running embedded in a Python process."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),
+    ('SciPy-bundle', '2023.07'),
+    ('R', '4.4.1'),  # BEAR Apps R version
+    ('R-bundle-CRAN', '2024.06'),  # BEAR Apps R version
+    ('IPython', '8.14.0'),
+    ('cffi', '1.15.1'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('coverage', '7.4.3', {
+        'checksums': ['276f6077a5c61447a48d133ed13e759c09e62aff0dc84274a68dc18660104d52'],
+    }),
+    ('pytest-cov', '4.1.0', {
+        'checksums': ['3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6'],
+    }),
+    ('tzlocal', '5.2', {
+        'checksums': ['8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e'],
+    }),
+    (name, version, {
+        'checksums': ['dbff08c30f3d79161922623858a5b3b68a3fba8ee1747d6af41bc4ba68f3d582'],
+    }),
+]
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1599727 - `rpy2-3.5.17-foss-2023a.eb`

Version bump from upstream `rpy2-3.5.15-foss-2023a.eb` to match our 2023a R version (4.4.1)

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
