### PR TITLE
TreeMix easyconf from upstream

### DIFF
--- a/easyconfigs/t/TreeMix/TreeMix-1.13-GCC-12.3.0.eb
+++ b/easyconfigs/t/TreeMix/TreeMix-1.13-GCC-12.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'TreeMix'
+version = '1.13'
+
+homepage = 'http://bitbucket.org/nygcresearch/treemix'
+description = """TreeMix is a method for inferring the patterns of population splits and mixtures in the history of a
+ set of populations."""
+
+toolchain = {'name': 'GCC', 'version': '12.3.0'}
+
+source_urls = ['https://bitbucket.org/nygcresearch/treemix/downloads/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['fe544f2daa13fd06b20c1a81aac728963ea5b66b75908916ca87ccd7f4cfa3d9']
+
+dependencies = [
+    ('GSL', '2.7'),
+    ('Boost', '1.82.0'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/treemix'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["treemix -h | grep 'TreeMix v. %(version)s'"]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1603332 - `TreeMix-1.13-GCC-12.3.0.eb`

Verbatim copy from upstream: <https://github.com/easybuilders/easybuild-easyconfigs/blob/4381b95ac913e5ee4308ab683094d9a08c307553/easybuild/easyconfigs/t/TreeMix/TreeMix-1.13-GCC-12.3.0.eb>

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
