### PR TITLE
CellChat 2.1.2 easyconf

### DIFF
--- a/easyconfigs/c/CellChat/CellChat-2.1.2-foss-2023a-R-4.4.1.eb
+++ b/easyconfigs/c/CellChat/CellChat-2.1.2-foss-2023a-R-4.4.1.eb
@@ -1,0 +1,51 @@
+easyblock = 'Bundle'
+
+name = 'CellChat'
+version = '2.1.2'
+versionsuffix = '-R-%(rver)s'
+
+homepage = 'https://github.com/jinworks/CellChat'
+description = """"
+R toolkit for inference, visualization and analysis of cell-cell communication
+from single-cell data"""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('R', '4.4.1'),
+    ('R-bundle-Bioconductor', '3.19', '-R-%(rver)s'),
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+    ('umap-learn', '0.5.5'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_default_options = {
+    'sources': ['%(name)s_%(version)s.tar.gz'],
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+}
+
+exts_list = [
+    ('ggalluvial', '0.12.5', {
+        'checksums': ['90044c880e70096137a733d601b11e558fe55e4e7d3aaacac6f08d7847415d71'],
+    }),
+    (name, version, {
+        'preinstallopts': "rm src/*.o src/*.so && ",
+        'source_urls': ['https://github.com/jinworks/CellChat/archive/'],
+        'sources': ['v%(version)s.tar.gz'],
+        'checksums': ['2ae82d85cb61b55d890a22ebee7ae1a95e191ca0a3275a0d7c1577e1ce4091fb'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': [name],
+}
+
+modextrapaths = {'R_LIBS_SITE': ''}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1605325 - `CellChat-2.1.2-foss-2023a-R-4.4.1.eb`

- modified from upstream
- uses new repo path (pre v2 repo is archived_
- removes depedencies on `systemfonts` and `svglite`, which are provided via `R` and `R-bundle-CRAN` respectively.

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
