### PR TITLE
INC1614829 fumi_tools install

### DIFF
--- a/easyconfigs/f/fumi_tools/fumi_tools-0.18.2-GCC-13.3.0.eb
+++ b/easyconfigs/f/fumi_tools/fumi_tools-0.18.2-GCC-13.3.0.eb
@@ -1,0 +1,34 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'CMakeMake'
+
+name = 'fumi_tools'
+version = '0.18.2'
+
+homepage = 'https://ccb-gitlab.cs.uni-saarland.de/tobias/fumi_tools'
+description = """This tool is intended to deduplicate UMIs from single-end and paired-end
+ sequencing data. Reads are considered identical when their UMIs have the same sequence,
+ they have the same length and map at the same position."""
+
+toolchain = {'name': 'GCC', 'version': '13.3.0'}
+
+source_urls = ['https://ccb-gitlab.cs.uni-saarland.de/tobias/%(name)s/uploads/bff8865d9eeaaa27849dd580aa2a9dd1/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['3570890e232f4a1862541c08d5755f11a12cf8972e2ee7461adc270ba4a220f1']
+
+builddependencies = [('CMake', '3.29.3')]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('pigz', '2.8'),
+    ('zlib', '1.3.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s'],
+    'dirs': []
+}
+
+sanity_check_commands = ["%(name)s -h"]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1614829 - `fumi_tools-0.18.2-GCC-13.3.0.eb`

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire

**Note:** Certain fumi_tools functions require SAMtools (but not as a dependency) hence the additional install https://github.com/bear-rsg/bear-eb/issues/645 
