### PR TITLE
ANSYS Rocky 2025R2 (including ANSYS 2025R2)

### DIFF
--- a/easyblocks/ansys.py
+++ b/easyblocks/ansys.py
@@ -1,0 +1,125 @@
+##
+# Copyright 2009-2025 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing ANSYS, implemented as an easyblock
+
+@author: Kenneth Hoste (Ghent University)
+@author: Bart Verleye (Centre for eResearch, Auckland)
+"""
+import os
+import re
+import stat
+from easybuild.tools import LooseVersion
+
+from easybuild.easyblocks.generic.packedbinary import PackedBinary
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import adjust_permissions, mkdir
+from easybuild.tools.run import run_shell_cmd
+
+
+class EB_ANSYS(PackedBinary):
+    """Support for installing ANSYS."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize ANSYS-specific variables."""
+        super().__init__(*args, **kwargs)
+        self.ansysver = None
+
+        # custom extra module environment entries for ANSYS
+        bin_dirs = [
+            'tgrid/bin',
+            'Framework/bin/Linux64',
+            'aisol/bin/linx64',
+            'RSM/bin',
+            'ansys/bin',
+            'autodyn/bin',
+            'CFD-Post/bin',
+            'CFX/bin',
+            'fluent/bin',
+            'TurboGrid/bin',
+            'polyflow/bin',
+            'Icepak/bin',
+            'icemcfd/linux64_amd/bin'
+        ]
+        if LooseVersion(self.version) >= LooseVersion('19.0'):
+            bin_dirs.append('CEI/bin')
+        # use glob pattern as we don't know exact version at this stage
+        # it will be expanded before injection into the module file
+        ansysver_glob = 'v[0-9]*'
+        self.module_load_environment.PATH = [os.path.join(ansysver_glob, d) for d in bin_dirs]
+
+    def install_step(self):
+        """Custom install procedure for ANSYS."""
+        # Sources (e.g. iso files) may drop the execute permissions
+        adjust_permissions('INSTALL', stat.S_IXUSR)
+
+        mkdir(f'{self.builddir}/tmp')
+        cmd = f"./INSTALL -silent -nochecks -install_dir {self.installdir} -usetempdir {self.builddir}/tmp"
+        # E.g. license.example.com or license1.example.com,license2.example.com
+        licserv = self.cfg.get('license_server') or os.getenv('EB_ANSYS_LICENSE_SERVER')
+        # E.g. '2325:1055' or just ':' to use those defaults
+        licport = self.cfg.get('license_server_port') or os.getenv('EB_ANSYS_LICENSE_SERVER_PORT')
+        if licserv is not None and licport is not None:
+            cmd += ' -licserverinfo %s:%s' % (licport, licserv)
+
+        run_shell_cmd(cmd)
+
+        adjust_permissions(self.installdir, stat.S_IWOTH, add=False)
+
+    def set_ansysver(self):
+        """Determine name of version subdirectory in installation directory."""
+        if LooseVersion(self.version) >= LooseVersion('2019'):
+            entries = os.listdir(self.installdir)
+            version_dir_regex = re.compile('^v[0-9]+')
+            version_dirs = [e for e in entries if version_dir_regex.match(e)]
+            if len(version_dirs) == 1:
+                self.ansysver = version_dirs[0]
+            else:
+                raise EasyBuildError("Failed to isolate version subdirectory in %s: %s", self.installdir, entries)
+        else:
+            self.ansysver = 'v' + ''.join(self.version.split('.')[0:2])
+
+    def make_module_extra(self):
+        """Define extra environment variables required by Ansys"""
+
+        if self.ansysver is None:
+            self.set_ansysver()
+
+        txt = super().make_module_extra()
+        icem_acn = os.path.join(self.installdir, self.ansysver, 'icemcfd', 'linux64_amd')
+        txt += self.module_generator.set_environment('ICEM_ACN', icem_acn)
+        return txt
+
+    def sanity_check_step(self):
+        """Custom sanity check for ANSYS."""
+
+        if self.ansysver is None:
+            self.set_ansysver()
+
+        custom_paths = {
+            'files': [os.path.join(self.ansysver, 'fluent', 'bin', 'fluent%s' % x) for x in ['', '_arch', '_sysinfo']],
+            'dirs': [os.path.join(self.ansysver, x) for x in ['ansys', 'aisol', 'CFD-Post', 'CFX']]
+        }
+        super().sanity_check_step(custom_paths=custom_paths)

--- a/easyconfigs/a/ANSYS/ANSYS-2025R2.eb
+++ b/easyconfigs/a/ANSYS/ANSYS-2025R2.eb
@@ -1,0 +1,45 @@
+name = 'ANSYS'
+version = '2025R2'
+
+homepage = 'https://www.ansys.com'
+description = """ANSYS simulation software enables organizations to confidently predict
+ how their products will operate in the real world. We believe that every product is
+ a promise of something greater."""
+
+toolchain = SYSTEM
+
+download_instructions = """Manually obtain the image files (e.g. ANSYS%(version)s_LINX64_DISKX.iso)
+ from your ANSYS vendor"""
+
+# Custom extract command is used since iso sources contain duplicate file.
+sources = [
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK1.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK2.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK3.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK4.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK5.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK6.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK7.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK8.iso', 'extract_cmd': '7z x -aos %s'},
+    {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK9.iso', 'extract_cmd': '7z x -aos %s'},
+]
+
+osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
+
+# Specify license_server and license_server_port here, or use EB_ANSYS_LICENSE_SERVER and EB_ANSYS_LICENSE_SERVER_PORT
+# license_server = "ansys.lic.example.com"
+# license_server_port = "1234:5678"
+
+# # To run the workbench "runwb2" certain deps are required, otherwise you get an error saying:
+# # "System.DllNotFoundException: Ans.QT.dll":
+# osdependencies = ['libxslt']
+
+modextravars = {
+    'KMP_AFFINITY': 'disabled',
+    'ANSYS252_DIR': '%(installdir)s/v252/ansys',  # Required for ANSYS_Rocky coupling
+    'AWP_ROOT252': '%(installdir)s/v252',  # Required for ANSYS_Rocky coupling
+}
+
+modtclfooter = "unsetenv UCX_NET_DEVICES"
+
+moduleclass = 'tools'

--- a/easyconfigs/a/ANSYS/ANSYS-2025R2.eb
+++ b/easyconfigs/a/ANSYS/ANSYS-2025R2.eb
@@ -23,6 +23,17 @@ sources = [
     {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK8.iso', 'extract_cmd': '7z x -aos %s'},
     {'filename': 'ANSYS%(version)s/ANSYS%(version)s_LINX64_DISK9.iso', 'extract_cmd': '7z x -aos %s'},
 ]
+checksums = [
+    {'ANSYS2025R2_LINX64_DISK1.iso': 'ea92e3673664d35b921f8f7180ce4465caf61039b84bff634f03fd53e48bb860'},
+    {'ANSYS2025R2_LINX64_DISK2.iso': '13d4b036bb14c2f653b13a233be6d574f50ed06014746b468072e1781498be4c'},
+    {'ANSYS2025R2_LINX64_DISK3.iso': '097b48151285ba3c3b26763595fd86b8899546cb8b35d18ffa8501c2c6cb80b6'},
+    {'ANSYS2025R2_LINX64_DISK4.iso': '5a83dcc88a844754547ba70a02c95509dec396dd2ba90f77e2e2f8fdd278085f'},
+    {'ANSYS2025R2_LINX64_DISK5.iso': '57cc79ce44a14072427e3de192b9dffc0900c627b48db9f7371310d333edab45'},
+    {'ANSYS2025R2_LINX64_DISK6.iso': '01fc43d78d392ded01d52953bd8506b9b203e3a5ec1d5c45ec4c21303112fc6e'},
+    {'ANSYS2025R2_LINX64_DISK7.iso': '06240286f31d21e86ff7672f20c400b268cdd3a93ac3d9afb3950c099247de68'},
+    {'ANSYS2025R2_LINX64_DISK8.iso': '53edeb8368bdcb2bd6a5b8620b56cd32854e3b85225b10874bfc68151c3e251f'},
+    {'ANSYS2025R2_LINX64_DISK9.iso': '9b66d9e0448f4e80e42ec47a9de96fbdde9948214e61a1682369f2d2ffbd50ff'},
+]
 
 osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
 

--- a/easyconfigs/a/ANSYS_Rocky/ANSYS_Rocky-2025R2.eb
+++ b/easyconfigs/a/ANSYS_Rocky/ANSYS_Rocky-2025R2.eb
@@ -1,0 +1,47 @@
+easyblock = 'CmdCp'
+
+name = 'ANSYS_Rocky'
+version = '2025R2'
+local_ansysver = 'v252'
+
+homepage = "https://www.ansys.com/en-gb/products/fluids/ansys-rocky"
+description = """Ansys Rocky is the industry-leading discrete element method (DEM)
+ software that quickly and accurately simulates particle flow behavior."""
+
+toolchain = SYSTEM
+
+download_instructions = """Login and download from https://download.ansys.com/currentReleases.
+Navigate to the "AddOn Packages" section and retrieve the "Main Package" download.
+"""
+
+sources = ["ROCKY_%(version)s_LINX64.tgz"]
+checksums = ['1dcc9857c136a1d506f4092813e8ac3f3080ca542516c9cb5c5246a10190da9c']
+
+dependencies = [
+    ('alsa-lib', '1.2.10'),
+    ('ANSYS', '2025R2'),
+    ('CUDA', '12.6.0'),  # Using CUDA version already available on BlueBEAR
+]
+
+cmds_map = [(
+    '.*',
+    "./INSTALL -silent -nochecks -install_dir %(installdir)s"
+)]
+
+skipsteps = ['install']  # the install step deletes the directory created by the above command
+files_to_copy = []
+
+postinstallcmds = [
+    "chmod +x %%(installdir)s/%s/rocky/Rocky*" % local_ansysver,
+]
+
+# Binaries are installed to the "rocky" subdirectory so add that to the PATH
+modextrapaths = {'PATH': '%s/rocky' % local_ansysver}
+
+sanity_check_paths = {
+    'files': ['%s/rocky/bin/%s' % (local_ansysver, x) for x in ['Rocky', 'RockySolver']]
+    + ['%s/rocky/bin/Rocky' % local_ansysver],
+    'dirs': ['%s/rocky/bin/%s' % (local_ansysver, x) for x in ['lib', 'share']],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1625321 - `ANSYS_Rocky-2025R2.eb`

The 9-ISO unpack requires a large amount of space in the buildpath and it's therefore necessary to move it to `/scratch` from `/dev/shm`:

```
export EASYBUILD_BUILDPATH=/scratch/${USER}/build-2024a-1
```

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
