### PR TITLE
doppio install for INC1632356

### DIFF
--- a/easyconfigs/d/doppio/doppio-1.2.1.eb
+++ b/easyconfigs/d/doppio/doppio-1.2.1.eb
@@ -14,7 +14,6 @@ sources = ['%(name)s-linux-%(version)s.zip']
 checksums = ['a4dd2fa125557fafde0cb756e254893b4a00c1f6762449ed40bdb7ef1df6abd1']
 
 postinstallcmds = [
-     #    Remove binaries for other platforms
     'mv %(builddir)s/* %(installdir)s/*',
     'mkdir -p %(installdir)s/bin',
     'ln -s %(installdir)s/themes/doppio-web/doppio-web %(installdir)s/bin/',


### PR DESCRIPTION
For INC1632356 - `doppio-1.2.1.eb`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
