### PR TITLE
HTSlib dep for nanomonsv

### DIFF
--- a/easyconfigs/n/nanomonsv/nanomonsv-0.8.0-foss-2023a.eb
+++ b/easyconfigs/n/nanomonsv/nanomonsv-0.8.0-foss-2023a.eb
@@ -15,6 +15,7 @@ dependencies = [
     ('python-parasail', '1.3.4'),
     ('Pysam', '0.22.0'),
     ('h5py', '3.9.0'),
+    ('HTSlib', '1.20'),
 ]
 
 exts_list = [


### PR DESCRIPTION
For INC1635678

Adds missing dep for nanomonsv's required binaries

```
eb nanomonsv-0.8.0-foss-2023a.eb -r --rebuild --module-only
```

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
