### PR TITLE
VEP

### DIFF
--- a/easyconfigs/v/VEP/VEP-115.2-GCC-13.3.0.eb
+++ b/easyconfigs/v/VEP/VEP-115.2-GCC-13.3.0.eb
@@ -39,8 +39,6 @@ exts_list = [
     }),
 ]
 
-postinstallcmds = ['chmod +x %(installdir)s/%(namelower)s']
-
 sanity_check_commands = ['vep --help']
 
 moduleclass = 'bio'


### PR DESCRIPTION
For INC1646772 - `VEP-115.2-GCC-13.3.0.eb`

I've removed the post install action to `chmod +x` the VEP perl file as the perms issues shouldn't affect the live installdir. If the sanity check fails, this will need to be modified.

For some reason, possibly my environment, I also had the source acquisition step attempt a download of `https://api.github.com/repos/Ensembl/ensembl/commits?sha=release/115` via HTTP. 

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
