### PR TITLE
xtb 6.7.1

### DIFF
--- a/easyconfigs/c/CPCM-X/CPCM-X-1.1.0-gfbf-2023a.eb
+++ b/easyconfigs/c/CPCM-X/CPCM-X-1.1.0-gfbf-2023a.eb
@@ -1,0 +1,49 @@
+# Author: J. Saßmannshausen (Imperial College London/UK)
+
+easyblock = 'MesonNinja'
+
+name = 'CPCM-X'
+version = '1.1.0'
+
+homepage = 'https://github.com/grimme-lab/CPCM-X'
+description = """This is an fully open source solvation model, based on the
+original conductor like screening model for realistic solvation (COSMO-RS)
+model by Klamt et al. in combination with the universal solvation model
+based on solute electron density (SMD) by Marenich, Cramer and Truhlar."""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+github_account = 'grimme-lab'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['4544cfec39f2294f7cd4ab5de3e72a6ddf09a976b25fa99fc8339cce7ee2933c']
+
+builddependencies = [
+    ('Meson', '1.3.1'),
+    ('Ninja', '1.11.1'),
+    ('pkgconf', '1.9.5'),
+]
+
+dependencies = [
+    ('mctc-lib', '0.3.1'),
+    ('mstore', '0.3.0'),
+    ('numsa', '0.2.0'),
+    ('TOML-Fortran', '0.4.2'),
+]
+
+_base_configopts = "-Dlapack='custom' -Dcustom_libraries='flexiblas' "
+configopts = [f'{_base_configopts} -Ddefault_library={x}' for x in ('static', 'shared')]
+
+runtest = 'meson'
+pretestopts = 'export OMP_NUM_THREADS=2 && '
+testopts = 'test -C %(builddir)s/easybuild_obj -t 60'  # Ensure test don't timeout
+
+sanity_check_paths = {
+    'files': ['bin/cpx'] +
+             ['lib/libcpx.%s' % e for e in ('a', SHLIB_EXT)],
+    'dirs': ['include'],
+}
+
+sanity_check_commands = ["cpx --help"]
+
+moduleclass = 'chem'

--- a/easyconfigs/d/dftd4/dftd4-3.7.0-gfbf-2023a.eb
+++ b/easyconfigs/d/dftd4/dftd4-3.7.0-gfbf-2023a.eb
@@ -1,0 +1,50 @@
+# A. Domingo (Vrije Universiteit Brussel)
+# J. Sassmannshausen (Imperial College London/UK)
+# C. Willemyns  (Vrije Universiteit Brussel)
+
+easyblock = 'CMakeNinja'
+
+name = 'dftd4'
+version = '3.7.0'
+
+homepage = 'https://dftd4.readthedocs.io'
+description = """
+The dftd4 project provides an implementation of the generally applicable, charge dependent
+London-dispersion correction, termed DFT-D4.
+"""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+toolchainopts = {'openmp': True}
+
+github_account = 'dftd4'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['f00b244759eff2c4f54b80a40673440ce951b6ddfa5eee1f46124297e056f69c']
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+    ('Ninja', '1.11.1'),
+]
+
+dependencies = [
+    ('mctc-lib', '0.3.1'),
+    ('mstore', '0.3.0'),
+    ('multicharge', '0.3.0'),
+]
+
+build_shared_libs = True
+
+configopts = '-DWITH_BLAS=1 -DWITH_OpenMP=1'
+
+# run suite of tests with ctest
+test_cmd = 'ctest'
+runtest = ''
+
+sanity_check_paths = {
+    'files': ['bin/dftd4', 'lib/libdftd4.%s' % SHLIB_EXT, 'include/dftd4.h'],
+    'dirs': ['include/dftd4', 'lib/cmake', 'lib/pkgconfig'],
+}
+
+sanity_check_commands = ["dftd4 --help"]
+
+moduleclass = 'chem'

--- a/easyconfigs/n/numsa/numsa-0.2.0-gfbf-2023a.eb
+++ b/easyconfigs/n/numsa/numsa-0.2.0-gfbf-2023a.eb
@@ -1,0 +1,42 @@
+# Author: J. Saßmannshausen (Imperial College London/UK)
+
+easyblock = 'MesonNinja'
+
+name = 'numsa'
+version = '0.2.0'
+
+homepage = 'https://github.com/grimme-lab/CPCM-X'
+description = """Numerical surface area integrator for molecular inputs.
+This project is based on routines from xtb and dftb+."""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+github_account = 'grimme-lab'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['3257a18a7f98c9cae2bc8e0cbb4f0171d2f94c4592ac0673b7932e0220f31d99']
+
+builddependencies = [
+    ('Meson', '1.3.1'),
+    ('Ninja', '1.11.1'),
+    ('pkgconf', '1.9.5'),
+]
+
+dependencies = [
+    ('mctc-lib', '0.3.1'),
+    ('mstore', '0.3.0'),
+]
+
+runtest = 'meson'
+pretestopts = 'export OMP_NUM_THREADS=2 && '
+testopts = 'test -C %(builddir)s/easybuild_obj -t 60'  # Ensure test don't timeout
+
+sanity_check_paths = {
+    'files': ['bin/numsa'] +
+             ['lib/libnumsa.%s' % e for e in ('a', SHLIB_EXT)],
+    'dirs': ['include'],
+}
+
+sanity_check_commands = ["numsa --help"]
+
+moduleclass = 'chem'

--- a/easyconfigs/t/tblite/tblite-0.4.0-gfbf-2023a.eb
+++ b/easyconfigs/t/tblite/tblite-0.4.0-gfbf-2023a.eb
@@ -1,0 +1,64 @@
+# Author: J. Sassmannshausen (Imperial College London/UK)
+
+easyblock = 'CMakeMake'
+
+name = 'tblite'
+version = '0.4.0'
+
+homepage = 'https://github.com/tblite/tblite'
+description = """Light-weight tight-binding framework"""
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+github_account = 'tblite'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+patches = [f'{name}-{version}_failed-test.patch']
+checksums = [
+    {'v0.4.0.tar.gz': 'c4a67dfbe04827095fd7598183e076fa3017a5a475c4f90fd28e78992dc19ea7'},
+    {'tblite-0.4.0_failed-test.patch': 'e2c4bd428ed8f264f992db17cf1bc6e6ae1642aaaa8c112bae134c9021fc886d'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('CMake', '3.26.3'),
+    ('meson-python', '0.15.0'),
+]
+
+dependencies = [
+    ('mctc-lib', '0.3.1'),
+    ('mstore', '0.3.0'),
+    ('Simple-DFTD3', '1.2.1'),
+    ('dftd4', '3.7.0'),
+    # for tblite Python bindings
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+]
+
+build_shared_libs = True
+
+# run suite of tests with ctest
+test_cmd = 'ctest --parallel 1'
+runtest = ''
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    (name, version, {
+        'checksums': ['c2334dced8e61e26cd24e1ddb53d10aa0d685cf4df451fc8547192163cddc113'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/tblite',
+              'lib/libtblite.%s' % SHLIB_EXT],
+    'dirs': ['include/%(name)s', 'lib/cmake', 'lib/pkgconfig',
+             'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["mctc-convert --help"]
+
+moduleclass = 'chem'

--- a/easyconfigs/x/xtb/xtb-6.7.1-gfbf-2023a.eb
+++ b/easyconfigs/x/xtb/xtb-6.7.1-gfbf-2023a.eb
@@ -1,0 +1,61 @@
+# Updated to use defined modules instead of relying on subdirectory ones
+# Author: J. Saßmannshausen (Imperial College London/UK)
+
+easyblock = 'MesonNinja'
+
+name = 'xtb'
+version = '6.7.1'
+
+homepage = 'https://xtb-docs.readthedocs.io'
+description = """ xtb - An extended tight-binding semi-empirical program package. """
+
+toolchain = {'name': 'gfbf', 'version': '2023a'}
+
+github_account = 'grimme-lab'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+patches = [
+    'xtb-6.7.1_fix-tblite-pr1072.patch',
+    'xtb-6.7.1_fix-dftd4-test.patch',
+]
+checksums = [
+    {'xtb-6.7.1.tar.gz': '52506a689147cdb4695bf1c666158b6d6d6b31726fecaa5bf53af7f4e3f3d20d'},
+    {'xtb-6.7.1_fix-tblite-pr1072.patch': '1f10fef3e94c29926b1f632acc94c3ec92be861ee5c5139104194172726ffe68'},
+    {'xtb-6.7.1_fix-dftd4-test.patch': '340e7d5cbc6bbaf0c53d4d292f3624cd67455b7a817818fe2cc8d26f5c34864b'},
+]
+
+builddependencies = [
+    ('Meson', '1.3.1'),
+    ('Ninja', '1.11.1'),
+    ('pkgconf', '1.9.5'),
+]
+
+dependencies = [
+    ('mctc-lib', '0.3.1'),
+    ('tblite', '0.4.0'),
+    ('mstore', '0.3.0'),
+    ('numsa', '0.2.0'),
+    ('CPCM-X', '1.1.0'),
+    ('dftd4', '3.7.0'),
+    ('Simple-DFTD3', '1.2.1'),
+]
+
+configopts = "-Dlapack='custom' -Dcustom_libraries='flexiblas' "
+
+runtest = 'meson'
+pretestopts = 'export OMP_NUM_THREADS=2 && '
+testopts = 'test -C %(builddir)s/easybuild_obj -t 60'  # Ensure test don't timeout
+
+sanity_check_paths = {
+    'files': ['bin/xtb', 'include/xtb.h'] + ['lib/libxtb.%s' % e for e in ('a', SHLIB_EXT)],
+    'dirs': ['share'],
+}
+
+sanity_check_commands = ["xtb --help"]
+
+modextravars = {
+    'XTBHOME': '%(installdir)s',
+    'XTBPATH': '%(installdir)s',
+}
+
+moduleclass = 'chem'

--- a/easyconfigs/x/xtb/xtb-6.7.1_fix-dftd4-test.patch
+++ b/easyconfigs/x/xtb/xtb-6.7.1_fix-dftd4-test.patch
@@ -1,0 +1,20 @@
+fix for failing xtb test:
+ 72/148 dftd4 / param                           FAIL              1.85s   exit status 1
+
+from meson-logs/testlog.txt:
+# Testing: param
+  Starting rational-damping ... (1/1)
+       ... rational-damping [FAILED]
+  Message: Condition not fullfilled
+
+see https://github.com/grimme-lab/xtb/pull/1085
+diff --git a/subprojects/dftd4.wrap b/subprojects/dftd4.wrap
+index 46dc07ad9..e3e93f459 100644
+--- a/subprojects/dftd4.wrap
++++ b/subprojects/dftd4.wrap
+@@ -1,4 +1,4 @@
+ [wrap-git]
+ directory = dftd4
+ url = https://github.com/dftd4/dftd4
+-revision = v3.5.0
++revision = v3.6.0

--- a/easyconfigs/x/xtb/xtb-6.7.1_fix-tblite-pr1072.patch
+++ b/easyconfigs/x/xtb/xtb-6.7.1_fix-tblite-pr1072.patch
@@ -1,0 +1,528 @@
+see https://github.com/grimme-lab/xtb/pull/1072 + https://github.com/grimme-lab/xtb/issues/1091
+diff --git a/src/dipro.F90 b/src/dipro.F90
+index 42a136364..ab64e0710 100644
+--- a/src/dipro.F90
++++ b/src/dipro.F90
+@@ -130,6 +130,10 @@ subroutine get_jab(env, tblite, mol, fragment, dipro)
+ !=========================set up calculator===========================================   
+ 
+    call get_calculator(xcalc, struc, tblite%method, error)  
++   if (allocated(error)) then
++      call env%error(error%message, source)
++      return
++   end if
+    call new_wavefunction(wfn, struc%nat, xcalc%bas%nsh, xcalc%bas%nao, & 
+       & 1, set%etemp * ktoau)
+    wfn%nspin=1
+@@ -258,6 +262,10 @@ subroutine get_jab(env, tblite, mol, fragment, dipro)
+       write(*,'(A,I2)') "unpaired e- of fragment : ", mfrag(ifr)%uhf
+ 
+       call get_calculator(fcalc(ifr), mfrag(ifr), tblite%method, error)
++      if (allocated(error)) then
++         call env%error(error%message, source)
++         return
++      end if
+       !> mol%charge is updated automatically from wfn by tblite library 
+       call new_wavefunction(wfx(ifr), mfrag(ifr)%nat, fcalc(ifr)%bas%nsh, fcalc(ifr)%bas%nao, &
+          & 1, set%etemp * ktoau)
+diff --git a/src/dipro/xtb.F90 b/src/dipro/xtb.F90
+index 95aff7848..4db948a3e 100644
+--- a/src/dipro/xtb.F90
++++ b/src/dipro/xtb.F90
+@@ -50,11 +50,11 @@ subroutine get_calculator(xcalc, mol, method, error)
+       call fatal_error(error, "Unknown method '"//method//"' requested")
+ !      error stop
+    case("gfn2")
+-      call new_gfn2_calculator(xcalc, mol)
++      call new_gfn2_calculator(xcalc, mol, error)
+    case("gfn1")
+-      call new_gfn1_calculator(xcalc, mol)
++      call new_gfn1_calculator(xcalc, mol, error)
+    case("ipea1")
+-      call new_ipea1_calculator(xcalc, mol)
++      call new_ipea1_calculator(xcalc, mol, error)
+    end select
+ end subroutine get_calculator
+ #endif
+diff --git a/src/tblite/calculator.F90 b/src/tblite/calculator.F90
+index 653e6b285..f05087414 100644
+--- a/src/tblite/calculator.F90
++++ b/src/tblite/calculator.F90
+@@ -150,16 +150,16 @@ subroutine newTBLiteCalculator(env, mol, calc, input)
+       case default
+          call fatal_error(error, "Unknown method '"//method//"' requested")
+       case("gfn2")
+-         call new_gfn2_calculator(calc%tblite, struc)
++         call new_gfn2_calculator(calc%tblite, struc, error)
+       case("gfn1")
+-         call new_gfn1_calculator(calc%tblite, struc)
++         call new_gfn1_calculator(calc%tblite, struc, error)
+       case("ipea1")
+-         call new_ipea1_calculator(calc%tblite, struc)
++         call new_ipea1_calculator(calc%tblite, struc, error)
+       case("ceh")
+          calc%guess = method
+          calc%nspin = 1
+-         calc%etemp = 5000.0_wp * kt
+-         call new_ceh_calculator(calc%tblite, struc)
++         calc%etemp = 4000.0_wp * kt
++         call new_ceh_calculator(calc%tblite, struc, error)
+       end select
+    end if
+    if (allocated(error)) then
+@@ -244,18 +244,18 @@ subroutine newTBLiteWavefunction(env, mol, calc, chk)
+          block 
+             use tblite_context, only : context_type, context_terminal
+             use tblite_context_terminal, only : escape
+-            use tblite_ceh_singlepoint, only : ceh_guess
++            use tblite_ceh_singlepoint, only : ceh_singlepoint
+             use tblite_lapack_solver, only : lapack_solver 
+             use tblite_lapack_solver, only : lapack_algorithm
+             type(context_type) :: ctx
+-            
++
+             ctx%solver = lapack_solver(lapack_algorithm%gvd)
+             ctx%terminal = context_terminal(calc%color)
+ 
+             write (env%unit, '(1x,a)') escape(ctx%terminal%cyan) // "Calculation of CEH charges" // &
+                & escape(ctx%terminal%reset)
+-            
+-            call ceh_guess(ctx, calc%tblite, struc, error, wfn, calc%accuracy, 1)
++
++            call ceh_singlepoint(ctx, calc%tblite, struc, wfn, calc%accuracy, 1)
+          end block
+       end select
+    end associate
+diff --git a/subprojects/mstore.wrap b/subprojects/mstore.wrap
+index acf5df9de..0dfe716c0 100644
+--- a/subprojects/mstore.wrap
++++ b/subprojects/mstore.wrap
+@@ -1,4 +1,4 @@
+ [wrap-git]
+ directory = mstore
+ url = https://github.com/grimme-lab/mstore
+-revision = v0.2.0
++revision = v0.3.0
+diff --git a/test/unit/test_ptb.F90 b/test/unit/test_ptb.F90
+index 16c14cbe4..5e585f90d 100644
+--- a/test/unit/test_ptb.F90
++++ b/test/unit/test_ptb.F90
+@@ -186,12 +186,37 @@ subroutine test_ptb_overlap(error)
+       !> (Scaled) overlap matrix
+       character(len=:), allocatable :: message
+       real(wp), parameter :: overlap_exp(6) = [ &
+-      & 0.93209460_wp, & ! 1,2
+-      & 0.35489609_wp, & ! 1,3
+-      & 0.65682608_wp, & ! 2,3
+-      & 0.05627743_wp, & ! 1,15
+-      & -0.14217162_wp, &  ! 1,24; diffferent because of tblite ordering
+-      & 0.41844087_wp] ! 14,23; diffferent because of tblite ordering
++      & 0.93209460_wp, & ! s(Mg)-s(Mg)
++      & 0.35489609_wp, & ! s(Mg)-s(Mg)
++      & 0.65682608_wp, & ! s(Mg)-s(Mg)
++      & 0.05627743_wp, & ! s(Mg)-s(H)
++      & -0.14217162_wp, & ! s(Mg)-pz(H)
++      & 0.41844087_wp] ! dyz(Mg)-py(H)
++      ! 1: s(Mg)
++      ! 2: s(Mg)
++      ! 3: s(Mg)
++      ! 4: py(Mg)
++      ! 5: pz(Mg)
++      ! 6: px(Mg)
++      ! 7: py(Mg)
++      ! 8: pz(Mg)
++      ! 9: px(Mg)
++      ! 10: dxy(Mg)
++      ! 11: dyz(Mg)
++      ! 12: dz2(Mg)
++      ! 13: dxz(Mg)
++      ! 14: dx2-y2(Mg)
++      ! 15: s(H)
++      ! 16: s(H)
++      ! 17: py(H)
++      ! 18: pz(H)
++      ! 19: px(H)
++      ! 20: s(H)
++      ! 21: s(H)
++      ! 22: py(H)
++      ! 23: pz(H)
++      ! 24: px(H)
++
+       real(wp), allocatable :: lattr(:, :)
+       real(wp) :: cutoff
+ 
+@@ -215,7 +240,7 @@ subroutine test_ptb_overlap(error)
+       call check_(error, ints%overlap(2, 3), overlap_exp(3), thr=thr)
+       call check_(error, ints%overlap(1, 15), overlap_exp(4), thr=thr)
+       call check_(error, ints%overlap(1, 23), overlap_exp(5), thr=thr)
+-      call check_(error, ints%overlap(12, 22), overlap_exp(6), thr=thr)
++      call check_(error, ints%overlap(11, 22), overlap_exp(6), thr=thr)
+ 
+    end subroutine test_ptb_overlap
+ 
+@@ -249,12 +274,37 @@ subroutine test_ptb_overlap_h0(error)
+       type(error_type), allocatable, intent(out) :: error
+       character(len=:), allocatable :: message
+       real(wp), parameter :: overlap_exp(6) = [ &
+-      & 0.95689468_wp, & ! 1,2
+-      & 0.39195790_wp, & ! 1,3
+-      & 0.62961212_wp, & ! 2,3
+-      & 0.03782850_wp, & ! 1,15
+-      &-0.13826216_wp, &  ! 1,24; diffferent because of tblite ordering
+-      & 0.43334922_wp] ! 14,23; diffferent because of tblite ordering
++      & 0.95689468_wp, & ! s(Mg)-s(Mg)
++      & 0.39195790_wp, & ! s(Mg)-s(Mg)
++      & 0.62961212_wp, & ! s(Mg)-s(Mg)
++      & 0.03782850_wp, & ! s(Mg)-s(H)
++      &-0.13826216_wp, & ! s(Mg)-pz(H)
++      & 0.43334922_wp] ! dyz(Mg)-py(H)
++      ! 1: s(Mg)
++      ! 2: s(Mg)
++      ! 3: s(Mg)
++      ! 4: py(Mg)
++      ! 5: pz(Mg)
++      ! 6: px(Mg)
++      ! 7: py(Mg)
++      ! 8: pz(Mg)
++      ! 9: px(Mg)
++      ! 10: dxy(Mg)
++      ! 11: dyz(Mg)
++      ! 12: dz2(Mg)
++      ! 13: dxz(Mg)
++      ! 14: dx2-y2(Mg)
++      ! 15: s(H)
++      ! 16: s(H)
++      ! 17: py(H)
++      ! 18: pz(H)
++      ! 19: px(H)
++      ! 20: s(H)
++      ! 21: s(H)
++      ! 22: py(H)
++      ! 23: pz(H)
++      ! 24: px(H)
++
+       real(wp), allocatable :: lattr(:, :)
+       real(wp) :: cutoff
+ 
+@@ -286,7 +336,7 @@ subroutine test_ptb_overlap_h0(error)
+       & message=message)
+       call check_(error, auxints%overlap_h0_1(1, 23), overlap_exp(5), thr=thr, &
+       & message=message)
+-      call check_(error, auxints%overlap_h0_1(12, 22), overlap_exp(6), thr=thr, &
++      call check_(error, auxints%overlap_h0_1(11, 22), overlap_exp(6), thr=thr, &
+       & message=message)
+ 
+    end subroutine test_ptb_overlap_h0
+@@ -319,12 +369,37 @@ subroutine test_ptb_overlap_SX(error)
+       real(wp), allocatable :: overlap_sx(:, :), overlap_oneminusx(:, :)
+       character(len=:), allocatable :: message
+       real(wp), parameter :: overlap_oneminusx_exp(6) = [ &
+-      & 0.70788_wp, & ! 1,2
+-      & 0.16203_wp, & ! 1,3
+-      & 0.41532_wp, & ! 2,3
+-      & 0.01449_wp, & ! 1,15
+-      &-0.07203_wp, &  ! 1,24; diffferent because of tblite ordering
+-      & 0.28751_wp] ! 14,23; diffferent because of tblite ordering
++      & 0.70788_wp, & ! s(Mg)-s(Mg)
++      & 0.16203_wp, & ! s(Mg)-s(Mg)
++      & 0.41532_wp, & ! s(Mg)-s(Mg)
++      & 0.01449_wp, & ! s(Mg)-s(H)
++      &-0.07203_wp, & ! s(Mg)-pz(H)
++      & 0.28751_wp] ! dyz(Mg)-py(H)
++      ! 1: s(Mg)
++      ! 2: s(Mg)
++      ! 3: s(Mg)
++      ! 4: py(Mg)
++      ! 5: pz(Mg)
++      ! 6: px(Mg)
++      ! 7: py(Mg)
++      ! 8: pz(Mg)
++      ! 9: px(Mg)
++      ! 10: dxy(Mg)
++      ! 11: dyz(Mg)
++      ! 12: dz2(Mg)
++      ! 13: dxz(Mg)
++      ! 14: dx2-y2(Mg)
++      ! 15: s(H)
++      ! 16: s(H)
++      ! 17: py(H)
++      ! 18: pz(H)
++      ! 19: px(H)
++      ! 20: s(H)
++      ! 21: s(H)
++      ! 22: py(H)
++      ! 23: pz(H)
++      ! 24: px(H)
++
+       real(wp), allocatable :: lattr(:, :)
+       real(wp) :: cutoff
+ 
+@@ -356,7 +431,7 @@ subroutine test_ptb_overlap_SX(error)
+       & message=message)
+       call check_(error, overlap_oneminusx(1, 23), overlap_oneminusx_exp(5), thr=thr2, &
+       & message=message)
+-      call check_(error, overlap_oneminusx(12, 22), overlap_oneminusx_exp(6), thr=thr2, &
++      call check_(error, overlap_oneminusx(11, 22), overlap_oneminusx_exp(6), thr=thr2, &
+       & message=message)
+ 
+    end subroutine test_ptb_overlap_SX
+@@ -392,10 +467,37 @@ subroutine test_ptb_V_ECP(error)
+       type(error_type), allocatable, intent(out) :: error
+       character(len=:), allocatable :: message
+       real(wp), parameter :: vecp_ref(4) = [ &
+-      &  0.077719_wp, & ! 1,1 ; diffferent because of tblite ordering
+-      & -0.059122_wp, & ! 1,3 ; diffferent because of tblite ordering
+-      &  0.052775_wp, & ! 3,5 ; diffferent because of tblite ordering
+-      &  0.117176_wp]   ! 9,9 ; diffferent because of tblite ordering
++      &  0.077719_wp, & ! s(B)-s(B)
++      & -0.059122_wp, & ! s(B)-px(B)
++      &  0.052775_wp, & ! px(B)-px(B)
++      &  0.117176_wp]   ! dx2-y2(B)-dx2-y2(B)
++      ! 1: s(B)
++      ! 2: s(B)
++      ! 3: py(B)
++      ! 4: pz(B)
++      ! 5: px(B)
++      ! 6: py(B)
++      ! 7: pz(B)
++      ! 8: px(B)
++      ! 9: dxy(B)
++      ! 10: dyz(B)
++      ! 11: dz2(B)
++      ! 12: dxz(B)
++      ! 13: dx2-y2(B)
++      ! 14: s(Cl)
++      ! 15: s(Cl)
++      ! 16: py(Cl)
++      ! 17: pz(Cl)
++      ! 18: px(Cl)
++      ! 19: py(Cl)
++      ! 20: pz(Cl)
++      ! 21: px(Cl)
++      ! 22: dxy(Cl)
++      ! 23: dyz(Cl)
++      ! 24: dz2(Cl)
++      ! 25: dxz(Cl)
++      ! 26: dx2-y2(Cl)
++
+       real(wp), parameter :: xyz(3, 2) = reshape([ &
+       & 2.0_wp, 0.0_wp, 0.0_wp, &
+       & 0.0_wp, 0.0_wp, 0.0_wp], [3, 2])
+@@ -434,7 +536,7 @@ subroutine test_ptb_V_ECP(error)
+       & message=message)
+       call check_(error, vecp(5, 8), vecp_ref(3), thr=thr2, &
+       & message=message)
+-      call check_(error, vecp(12, 12), vecp_ref(4), thr=thr2, &
++      call check_(error, vecp(13, 13), vecp_ref(4), thr=thr2, &
+       & message=message)
+    end subroutine test_ptb_V_ECP
+ 
+@@ -629,12 +731,39 @@ subroutine test_ptb_hamiltonian_h0(error)
+       real(wp), allocatable :: vecp(:, :)
+ 
+       real(wp), parameter :: h0_ref(6) = [ &
+-      &  -1.59330281_wp, & ! 1,1
+-      &  -2.24996207_wp, & ! 1,2
+-      &   0.34974782_wp, & ! 1,23 ; diffferent because of tblite ordering
+-      &   0.0_wp, & ! 7,11 ; different because of tblite ordering
+-      &  -1.17757007_wp, & ! 3,6 ; different because of tblite ordering
+-      &   0.48301561_wp]   ! 11,24 ; diffferent because of tblite ordering
++      &  -1.59330281_wp, & ! s(B)-s(B)
++      &  -2.24996207_wp, & ! s(B)-s(B)
++      &   0.34974782_wp, & ! s(B)-py(Cl)
++      &   0.0_wp, & ! dx2-y2(B)-py(B)
++      &  -1.17757007_wp, & ! px(B)-px(B)
++      &   0.48301561_wp]   ! dxy(B)-dxy(Cl)
++      ! 1: s(B)
++      ! 2: s(B)
++      ! 3: py(B)
++      ! 4: pz(B)
++      ! 5: px(B)
++      ! 6: py(B)
++      ! 7: pz(B)
++      ! 8: px(B)
++      ! 9: dxy(B)
++      ! 10: dyz(B)
++      ! 11: dz2(B)
++      ! 12: dxz(B)
++      ! 13: dx2-y2(B)
++      ! 14: s(Cl)
++      ! 15: s(Cl)
++      ! 16: py(Cl)
++      ! 17: pz(Cl)
++      ! 18: px(Cl)
++      ! 19: py(Cl)
++      ! 20: pz(Cl)
++      ! 21: px(Cl)
++      ! 22: dxy(Cl)
++      ! 23: dyz(Cl)
++      ! 24: dz2(Cl)
++      ! 25: dxz(Cl)
++      ! 26: dx2-y2(Cl)
++
+       real(wp), parameter :: levels(10) = [ &
+       &    -0.796651404_wp, &
+       &    -0.269771638_wp, &
+@@ -665,15 +794,16 @@ subroutine test_ptb_hamiltonian_h0(error)
+          & alpha_scal=id_to_atom(mol, ptbData%hamiltonian%kalphah0l))
+       allocate (vecp(bas%nao, bas%nao), source=0.0_wp)
+ 
++      ints%hamiltonian = 0.0_wp
+       call get_hamiltonian(mol, list, bas, ptbData%hamiltonian, ptbData%hamiltonian%kla, auxints%overlap_h0_1, &
+       & levels, ints%hamiltonian, ptbGlobals%kpol, ptbGlobals%kitr, ptbGlobals%kitocod)
+       message = "H0 matrix element not matching to expected value."
+       call check_(error, ints%hamiltonian(1, 1), h0_ref(1), thr=thr)
+       call check_(error, ints%hamiltonian(1, 2), h0_ref(2), thr=thr)
+-      call check_(error, ints%hamiltonian(1, 22), h0_ref(3), thr=thr)
++      call check_(error, ints%hamiltonian(1, 24), h0_ref(3), thr=thr)
+       call check_(error, ints%hamiltonian(13, 6), h0_ref(4), thr=thr)
+       call check_(error, ints%hamiltonian(8, 5), h0_ref(5), thr=thr)
+-      call check_(error, ints%hamiltonian(13, 26), h0_ref(6), thr=thr)
++      call check_(error, ints%hamiltonian(9, 22), h0_ref(6), thr=thr)
+    end subroutine test_ptb_hamiltonian_h0
+ 
+    subroutine test_ptb_V_XC(error)
+@@ -708,10 +838,37 @@ subroutine test_ptb_V_XC(error)
+       type(error_type), allocatable, intent(out) :: error
+       character(len=:), allocatable :: message
+       real(wp), parameter :: Vxc_ref(4) = [ &
+-      & -0.92793357_wp, & ! 1,1
+-      & -0.85981333_wp, & ! 1,2
+-      &  0.06632750_wp, & ! 1,23 ; diffferent because of tblite ordering
+-      &  0.00151880_wp]   ! 11,24 ; diffferent because of tblite ordering
++      & -0.92793357_wp, & ! s(B)-s(B)
++      & -0.85981333_wp, & ! s(B)-s(B)
++      &  0.06632750_wp, & ! s(B)-dz2(Cl)
++      &  0.00151880_wp]   ! dxy(B)-dxy(Cl)
++      ! 1: s(B)
++      ! 2: s(B)
++      ! 3: py(B)
++      ! 4: pz(B)
++      ! 5: px(B)
++      ! 6: py(B)
++      ! 7: pz(B)
++      ! 8: px(B)
++      ! 9: dxy(B)
++      ! 10: dyz(B)
++      ! 11: dz2(B)
++      ! 12: dxz(B)
++      ! 13: dx2-y2(B)
++      ! 14: s(Cl)
++      ! 15: s(Cl)
++      ! 16: py(Cl)
++      ! 17: pz(Cl)
++      ! 18: px(Cl)
++      ! 19: py(Cl)
++      ! 20: pz(Cl)
++      ! 21: px(Cl)
++      ! 22: dxy(Cl)
++      ! 23: dyz(Cl)
++      ! 24: dz2(Cl)
++      ! 25: dxz(Cl)
++      ! 26: dx2-y2(Cl)
++
+       real(wp), parameter :: xyz(3, 2) = reshape([ &
+       & 2.0_wp, 0.0_wp, 0.0_wp, &
+       & 0.0_wp, 0.0_wp, 0.0_wp], [3, 2])
+@@ -769,9 +926,9 @@ subroutine test_ptb_V_XC(error)
+       & message=message)
+       call check_(error, Vxc(1, 2), Vxc_ref(2), thr=thr, &
+       & message=message)
+-      call check_(error, Vxc(1, 22), Vxc_ref(3), thr=thr, &
++      call check_(error, Vxc(1, 24), Vxc_ref(3), thr=thr, &
+       & message=message)
+-      call check_(error, Vxc(13, 26), Vxc_ref(4), thr=thr, &
++      call check_(error, Vxc(9, 22), Vxc_ref(4), thr=thr, &
+       & message=message)
+ 
+    end subroutine test_ptb_V_XC
+@@ -957,10 +1114,35 @@ subroutine test_ptb_coulomb_potential(error)
+       !> Conversion factor from temperature to energy
+       real(wp), parameter :: kt = 3.166808578545117e-06_wp
+       real(wp), parameter :: coulomb_pot_ref(4) = [ &
+-      &  -0.05693153_wp, & ! 1,1
+-      &  -0.33917531_wp, & ! 1,2
+-      &  -0.00539212_wp, & ! 1,21 ; diffferent because of tblite ordering
+-      &   0.01305793_wp]   ! 6,24 ; diffferent because of tblite ordering
++      &  -0.05693153_wp, & ! s(Mg)-s(Mg)
++      &  -0.33917531_wp, & ! s(Mg)-s(Mg)
++      &  -0.00539212_wp, & ! s(Mg)-s(H)
++      &   0.01305793_wp]   ! pz(Mg)-pz(H)
++      ! 1: s(Mg)
++      ! 2: s(Mg)
++      ! 3: s(Mg)
++      ! 4: py(Mg)
++      ! 5: pz(Mg)
++      ! 6: px(Mg)
++      ! 7: py(Mg)
++      ! 8: pz(Mg)
++      ! 9: px(Mg)
++      ! 10: dxy(Mg)
++      ! 11: dyz(Mg)
++      ! 12: dz2(Mg)
++      ! 13: dxz(Mg)
++      ! 14: dx2-y2(Mg)
++      ! 15: s(H)
++      ! 16: s(H)
++      ! 17: py(H)
++      ! 18: pz(H)
++      ! 19: px(H)
++      ! 20: s(H)
++      ! 21: s(H)
++      ! 22: py(H)
++      ! 23: pz(H)
++      ! 24: px(H)
++
+       real(wp), allocatable :: lattr(:, :)
+       real(wp) :: cutoff
+ 
+@@ -1044,10 +1226,36 @@ subroutine test_ptb_plus_U_potential(error)
+       integer, parameter :: nat = 2
+       integer, parameter :: at(nat) = [5, 17]
+       real(wp), parameter :: plusU_pot_ref(4) = [ &
+-      &  -0.0023185_wp, & ! 1,1
+-      &  -0.0018289_wp, & ! 1,2
+-      &  -0.5266562_wp, & ! 1,21 ; diffferent because of tblite ordering
+-      &  -1.6745659_wp]   ! 6,24 ; diffferent because of tblite ordering
++      &  -0.0023185_wp, & ! s(B)-s(B)
++      &  -0.0018289_wp, & ! s(B)-s(B)
++      &  -0.5266562_wp, & ! s(B)-pz(Cl)
++      &  -1.6745659_wp]   ! px(B)-dxy(Cl)
++      ! 1: s(B)
++      ! 2: s(B)
++      ! 3: py(B)
++      ! 4: pz(B)
++      ! 5: px(B)
++      ! 6: py(B)
++      ! 7: pz(B)
++      ! 8: px(B)
++      ! 9: dxy(B)
++      ! 10: dyz(B)
++      ! 11: dz2(B)
++      ! 12: dxz(B)
++      ! 13: dx2-y2(B)
++      ! 14: s(Cl)
++      ! 15: s(Cl)
++      ! 16: py(Cl)
++      ! 17: pz(Cl)
++      ! 18: px(Cl)
++      ! 19: py(Cl)
++      ! 20: pz(Cl)
++      ! 21: px(Cl)
++      ! 22: dxy(Cl)
++      ! 23: dyz(Cl)
++      ! 24: dz2(Cl)
++      ! 25: dxz(Cl)
++      ! 26: dx2-y2(Cl)
+ 
+       call new(mol, at, xyz)
+       allocate (ptbData)
+@@ -1067,7 +1275,7 @@ subroutine test_ptb_plus_U_potential(error)
+       call check_(error, wfn%coeff(1, 1, 1), plusU_pot_ref(1), thr=thr)
+       call check_(error, wfn%coeff(1, 2, 1), plusU_pot_ref(2), thr=thr)
+       call check_(error, wfn%coeff(1, 20, 1), plusU_pot_ref(3), thr=thr)
+-      call check_(error, wfn%coeff(8, 26, 1), plusU_pot_ref(4), thr=thr)
++      call check_(error, wfn%coeff(8, 22, 1), plusU_pot_ref(4), thr=thr)
+ 
+    end subroutine test_ptb_plus_U_potential
+ 


### PR DESCRIPTION
For INC1656257 - `xtb-6.7.1-gfbf-2023a.eb`

Upstream version in 2023b modified for installation in 2023a as it is to be used with Orca 6.0, which we have in 2023a. Upstream `xtb-6.7.0-gfbf-2023a.eb` not used as `xtb 6.7.1` was released as a "Bugfix release for the upcoming ORCA 6".

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
