### PR TITLE
Lates version of Julia for INC1663756

### DIFF
--- a/easyconfigs/j/Julia/Julia-1.12.2-linux-x86_64.eb
+++ b/easyconfigs/j/Julia/Julia-1.12.2-linux-x86_64.eb
@@ -1,0 +1,38 @@
+# This file is an EasyBuild reciPY as per https://easybuilders.github.io/easybuild/
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics
+# Updated by: Dugan Witherick, University of Warwick
+#             Robert Mijakovic <robert.mijakovic@lxp.lu>
+#             Wahid Mainassara <wahid.mainassara@lxp.lu>
+#             Paul Melis <paul.melis@surf.nl>
+
+easyblock = 'Tarball'
+
+name = 'Julia'
+version = '1.12.2'
+versionsuffix = '-linux-x86_64'
+
+homepage = 'https://julialang.org'
+description = "Julia is a high-level, high-performance dynamic programming language for numerical computing"
+
+toolchain = SYSTEM
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s%(versionsuffix)s.tar.gz']
+patches = [('julia.wrapper', 'bin/')]
+checksums = [
+    {'julia-1.12.2-linux-x86_64.tar.gz': 'a6d0c39ea57303ebcffa7a8d453429b86eb271e150c7cb0f5958fe65909b493a'},
+    {'julia.wrapper': 'a36a3e0cb98ab4d2b05e0ca8f0bf2724baafbd669a0db318a00e40737d2f02f9'},
+]
+
+# install wrapper with linking safeguards for Julia libraries
+postinstallcmds = ["cd %(installdir)s/bin && mv julia julia.bin && mv julia.wrapper julia && chmod +x julia"]
+
+sanity_check_paths = {
+    'files': ['bin/julia', 'bin/julia.bin', 'include/julia/julia.h', 'lib/libjulia.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'etc', 'include', 'lib', 'lib/julia', 'share']
+}
+sanity_check_commands = ['julia --help']
+
+moduleclass = 'lang'


### PR DESCRIPTION
For INC1663756 - `Julia-1.12.2-linux-x86_64.eb`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire

**Note:** I had to add `chmod +x` due to permission issue with the execuatble julia (line 30)