### PR TITLE
MATLAB 2024b-r6 and deps

### DIFF
--- a/easyconfigs/m/MATLAB/MATLAB-2024b-r6.eb
+++ b/easyconfigs/m/MATLAB/MATLAB-2024b-r6.eb
@@ -1,0 +1,31 @@
+name = 'MATLAB'
+version = '2024b'
+_update = '6'
+versionsuffix = '-r%s' % _update
+
+homepage = 'https://www.mathworks.com/products/matlab'
+description = """MATLAB is a high-level language and interactive environment
+ that enables you to perform computationally intensive tasks faster than with
+ traditional programming languages such as C, C++, and Fortran."""
+
+toolchain = SYSTEM
+
+sources = ['R%s_Update_%s_Linux.iso' % (version, _update)]
+checksums = ['c6dc8163b2e702148ac74fd71ae8094c5e4d893f57c894f80d9edf022df9740b']
+
+download_instructions = f'Download {sources[0]} from mathworks.com'
+
+java_options = '-Xmx2048m'
+
+osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
+dependencies = [('MathWorksServiceHost', '2025.10.0.2')]
+
+# Use EB_MATLAB_KEY environment variable or uncomment and modify license key
+# key = '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000'
+
+# Use EB_MATLAB_LICENSE_SERVER and EB_MATLAB_LICENSE_SERVER_PORT environment variables or
+# uncomment and modify the following variables for installation with floating license server
+# license_file = 'my-license-file'
+# license_server_port = 'XXXXX'
+
+moduleclass = 'math'

--- a/easyconfigs/m/MathWorksServiceHost/MathWorksServiceHost-2025.10.0.2.eb
+++ b/easyconfigs/m/MathWorksServiceHost/MathWorksServiceHost-2025.10.0.2.eb
@@ -1,0 +1,35 @@
+easyblock = 'Tarball'
+
+name = 'MathWorksServiceHost'
+version = '2025.10.0.2'
+
+homepage = ''
+# https://github.com/mathworks-ref-arch/administer-mathworks-service-host
+description = """MathWorks Service Host is a collection of background processes that provide
+ required services to MATLAB and other MathWorks products. Starting from MATLAB Release
+ 2024a, MATLAB requires MathWorks Service Host."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://ssd.mathworks.com/supportfiles/downloads/MathWorksServiceHost/v%(version)s/release/glnxa64/']
+sources = ['managed_mathworksservicehost_%(version)s_package_glnxa64.zip']
+checksums = ['29634bf90a7efd2762d51e2bd646dc830b424b723a07cf889488aac4ba091771']
+
+postinstallcmds = [
+    'echo "LatestDSInstallerVersion %(version)s" > %(installdir)s/LatestInstall.info',
+    'echo "LatestDSInstallRoot %(installdir)s" >> %(installdir)s/LatestInstall.info',
+    'echo "DSLauncherExecutable %(installdir)s/bin/glnxa64/MathWorksServiceHost" >> %(installdir)s/LatestInstall.info',
+]
+
+sanity_check_paths = {
+    'files': ['bin/MATLABConnector', 'bin/glnxa64/MathWorksServiceHost'],
+    'dirs': ['bin', 'cefclient', 'extern', 'help', 'resources', 'sys', 'toolbox', 'ui'],
+}
+
+sanity_check_commands = ['MATLABConnector help']
+
+# Force MATLAB to use the installed version. Otherwise, MATLAB automatically installs the
+# latest version of MathWorks Service Host for each host into `$HOME/MathWorks` on Linux
+modextrapaths = {'MATHWORKS_SERVICE_HOST_MANAGED_INSTALL_ROOT': ''}
+
+moduleclass = 'math'


### PR DESCRIPTION
For INC1663916 - `MATLAB-2024b-r6.eb` (build against `2023a`)

N.B. requires various licence-related environment variables to be set!

* [x] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
