### PR TITLE
set `FI_PROVIDER=verbs` in ANSYS

### DIFF
--- a/easyconfigs/a/ANSYS/ANSYS-2023R1.eb
+++ b/easyconfigs/a/ANSYS/ANSYS-2023R1.eb
@@ -31,7 +31,7 @@ osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
 # # "System.DllNotFoundException: Ans.QT.dll":
 # osdependencies = ['libxslt']
 
-modextravars = {'KMP_AFFINITY': 'disabled'}
+modextravars = {'KMP_AFFINITY': 'disabled', 'FI_PROVIDER': 'verbs'}
 
 modtclfooter = """unsetenv UCX_NET_DEVICES
 unsetenv I_MPI_HYDRA_BOOTSTRAP_EXEC_EXTRA_ARGS"""

--- a/easyconfigs/a/ANSYS/ANSYS-2024R1.eb
+++ b/easyconfigs/a/ANSYS/ANSYS-2024R1.eb
@@ -31,7 +31,7 @@ osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
 # # "System.DllNotFoundException: Ans.QT.dll":
 # osdependencies = ['libxslt']
 
-modextravars = {'KMP_AFFINITY': 'disabled'}
+modextravars = {'KMP_AFFINITY': 'disabled', 'FI_PROVIDER': 'verbs'}
 
 modtclfooter = """unsetenv UCX_NET_DEVICES
 unsetenv I_MPI_HYDRA_BOOTSTRAP_EXEC_EXTRA_ARGS"""

--- a/easyconfigs/a/ANSYS/ANSYS-2024R2.eb
+++ b/easyconfigs/a/ANSYS/ANSYS-2024R2.eb
@@ -35,6 +35,7 @@ osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
 
 modextravars = {
     'KMP_AFFINITY': 'disabled',
+    'FI_PROVIDER': 'verbs',
     'ANSYS242_DIR': '%(installdir)s/v242/ansys',  # Required for ANSYS_Rocky coupling
     'AWP_ROOT242': '%(installdir)s/v242',  # Required for ANSYS_Rocky coupling
 }

--- a/easyconfigs/a/ANSYS/ANSYS-2025R2.eb
+++ b/easyconfigs/a/ANSYS/ANSYS-2025R2.eb
@@ -47,6 +47,7 @@ osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
 
 modextravars = {
     'KMP_AFFINITY': 'disabled',
+    'FI_PROVIDER': 'verbs',
     'ANSYS252_DIR': '%(installdir)s/v252/ansys',  # Required for ANSYS_Rocky coupling
     'AWP_ROOT252': '%(installdir)s/v252',  # Required for ANSYS_Rocky coupling
 }


### PR DESCRIPTION
No rebuild required - manually edited all relevant modules:
* [x] `2022a/EL8-ice`
* [x] `2022b/EL8-ice`
* [x] `2023a/EL8-ice`
* [x] `2023a/EL8-spr`
* [x] `2024a/EL8-ice`
* [x] `2024a/EL8-spr`