### PR TITLE
Add alsa-lib to MATLAB R2024b dependencies

### DIFF
--- a/easyconfigs/m/MATLAB/MATLAB-2024b-r6.eb
+++ b/easyconfigs/m/MATLAB/MATLAB-2024b-r6.eb
@@ -18,7 +18,10 @@ download_instructions = f'Download {sources[0]} from mathworks.com'
 java_options = '-Xmx2048m'
 
 osdependencies = [('p7zip-plugins', 'p7zip-full')]  # for extracting iso-files
-dependencies = [('MathWorksServiceHost', '2025.10.0.2')]
+dependencies = [
+    ('MathWorksServiceHost', '2025.10.0.2'),
+    ('alsa-lib', '1.2.10'),  # libasound.so.2 is required for various elements of MATLAB
+]
 
 # Use EB_MATLAB_KEY environment variable or uncomment and modify license key
 # key = '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000-00000'


### PR DESCRIPTION
For INC1668761

```
eb MATLAB-2024b-r6.eb --module-only --rebuild
```

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
