### PR TITLE
Code Server 4.107.0 (against 2024a)

### DIFF
--- a/easyconfigs/c/code-server/code-server-4.107.0.eb
+++ b/easyconfigs/c/code-server/code-server-4.107.0.eb
@@ -8,5 +8,6 @@ toolchain = SYSTEM
 
 source_urls = ['https://github.com/coder/code-server/releases/download/v%(version)s/']
 sources = ['code-server-%(version)s-linux-%(mapped_arch)s.tar.gz']
+checksums = ['4fa96bb9b21f7e2c91c06bc1e72b79d6bebc86924a61b14633b88e297731ce24']
 
 moduleclass = 'tools'


### PR DESCRIPTION
For INC1670670 - `code-server-4.107.0.eb`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
