### PR TITLE
Cartopy

### DIFF
--- a/easyconfigs/c/Cartopy/Cartopy-0.24.1-foss-2024a.eb
+++ b/easyconfigs/c/Cartopy/Cartopy-0.24.1-foss-2024a.eb
@@ -1,0 +1,51 @@
+easyblock = 'PythonBundle'
+
+name = 'Cartopy'
+version = '0.24.1'
+
+homepage = 'https://scitools.org.uk/cartopy/docs/latest/'
+description = """Cartopy is a Python package designed to make drawing maps for data analysis and visualisation easy."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+builddependencies = [
+    ('Cython', '3.0.10'),
+]
+dependencies = [
+    ('Python', '3.12.3'),
+    ('Python-bundle-PyPI', '2024.06'),
+    ('Fiona', '1.10.1'),
+    ('GDAL', '3.10.0'),
+    ('GEOS', '3.12.2'),
+    ('matplotlib', '3.9.2'),
+    ('pyproj', '3.7.0'),
+    ('SciPy-bundle', '2024.05'),
+    ('Shapely', '2.1.0'),  # BEAR Fiona ec mods Shapely dep version so 2.1.0 required here.
+    ('lxml', '5.3.0'),
+    ('Pillow', '10.4.0'),
+    ('PROJ', '9.4.1'),
+    ('PyYAML', '6.0.2'),
+]
+
+exts_list = [
+    ('OWSLib', '0.32.0', {
+        'checksums': ['7513860d3102ae8d4dc5efd8652ff3c61eca3a8cb220d6c8601121357cd2b01a'],
+    }),
+    ('pyepsg', '0.4.0', {
+        'checksums': ['2d08fad1e7a8b47a90a4e43da485ba95705923425aefc4e2a3efa540dbd470d7'],
+    }),
+    ('pykdtree', '1.3.13', {
+        'checksums': ['3accf852e946653e399c3d4dbbe119dbc6d3f72cfd2d5a95cabf0bf0c7f924fe'],
+    }),
+    ('pyshp', '2.3.1', {
+        'modulename': 'shapefile',
+        'checksums': ['4caec82fd8dd096feba8217858068bacb2a3b5950f43c048c6dc32a3489d5af1'],
+    }),
+    (name, version, {
+        'preinstallopts': r"sed -i 's/dynamic = \[\"version\"\]/version = \"%(version)s\"/g' pyproject.toml && ",
+        'sources': ['cartopy-%(version)s.tar.gz'],
+        'checksums': ['01c910d5634c69a7efdec46e0a17d473d2328767f001d4dc0b5c4b48e585c8bd'],
+    }),
+]
+
+moduleclass = 'geo'


### PR DESCRIPTION
For INC1672612 - `Cartopy-0.24.1-foss-2024a.eb`

+ Modification to upstream file - Shapely dep change needed

In addition to PyQT5 and ecCodes upstream builds in https://github.com/bear-rsg/bear-eb/issues/773

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
