### PR TITLE
Eggnog mapper

### DIFF
--- a/easyconfigs/e/eggnog-mapper/eggnog-mapper-2.1.13-foss-2024a.eb
+++ b/easyconfigs/e/eggnog-mapper/eggnog-mapper-2.1.13-foss-2024a.eb
@@ -45,7 +45,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     'download_eggnog_data.py --help',
     'create_dbs.py --help',
-    'mkdir -p $EGGNOG_DATA_DIR && emapper.py --version | grep %(version)s',
+    'mkdir -p $EGGNOG_DATA_DIR && download_eggnog_data.py -y -F && emapper.py --version | grep %(version)s',
 ]
 
 modextravars = {'EGGNOG_DATA_DIR': '%(installdir)s/downloaded_db'}


### PR DESCRIPTION
For INC1681976 - `eggnog-mapper-2.1.13-foss-2024a.eb`

Post-install download instructions:
```
export EGGNOG_DATA_DIR
mkdir -p EGGNOG_DATA_DIR
download_eggnog_data.py -y -F
emapper.py --version

```
Downloads and unpacks:
> `eggnog.db` - main annotation database
> `eggnog.taxa.db` - taxa database
> `eggnog_proteins.dmnd` - diamond database
> `novel_fams.dmnd` - novel families diamond and annotation databases
uses -F flag to download requested `novel_fams.dmnd`
Total size: `6.3G + 69M + 4.9G + 1.3G`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
