### PR TITLE
Dorado for INC1682088

### DIFF
--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -44,6 +44,22 @@ dependencies = [
     ('libaec', '1.1.3'),
 ]
 
+# don't use vendored HTSlib, use provided HTSlib dependency
+#preconfigopts += "rm -r ../dorado/dorado/3rdparty/htslib/ && "
+preconfigopts = "rm -r ../dorado/dorado/3rdparty/htslib/ && " # Command worked
+preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/CMakeLists.txt && " # Command worked
+preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/dorado/utils/CMakeLists.txt && "
+preconfigopts += "sed -i '/Htslib.cmake/d' ../dorado/CMakeLists.txt && "
+# rename link target 'htslib' -> 'hts' only in CMake files, excluding kadayashi's cmake dir
+preconfigopts += r"find ../dorado -type f \( -name CMakeLists.txt -o -name '*.cmake' \) "
+preconfigopts += "-not -path '../dorado/dorado/3rdparty/kadayashi/cmake/*' -print0 | "
+preconfigopts += r"xargs -0 sed -i -E 's/\<htslib\>/hts/g' && "
+# keep kadayashi's find_package on 'htslib' and make it return -lhts via its finder
+preconfigopts += r"sed -i -E 's/find_package\(\s*hts\b/find_package(htslib/' "
+preconfigopts += "../dorado/dorado/3rdparty/kadayashi/CMakeLists.txt && "
+preconfigopts += r"sed -i -E 's/\bset\(HTSLIB_LIBRARIES\s+htslib(::hts)?\)/set(HTSLIB_LIBRARIES hts)/' "
+preconfigopts += "../dorado/dorado/3rdparty/kadayashi/cmake/Findhtslib.cmake && "
+
 _copts = [
     "-DCUDA_TOOLKIT_ROOT_DIR=$EBROOTCUDA",
     "-DCMAKE_CUDA_COMPILER=$EBROOTCUDA/bin/nvcc",

--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -61,7 +61,7 @@ configopts = ' '.join(_copts) + ' '
 configopts += "$(if %(rpath_enabled)s; then "
 configopts += "echo '-DCMAKE_SKIP_INSTALL_RPATH=YES -DCMAKE_SKIP_RPATH=YES'; fi) "
 
-prebuildopts = 'sed -i "s/HTSCODECS\_VERSION\_TEXT/HTSCODECS\_VERSION/" htslib_build/htslib/Makefile '
+prebuildopts = r'sed -i "s/HTSCODECS\_VERSION\_TEXT/HTSCODECS\_VERSION/" htslib_build/htslib/Makefile '
 prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/Makefile.am '
 prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/htscodecs.c && '
 

--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -1,0 +1,87 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'CMakeMake'
+
+name = 'dorado'
+version = '1.4.0'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://github.com/nanoporetech/dorado'
+description = """Dorado is a high-performance, easy-to-use, open source basecaller for Oxford Nanopore reads."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/nanoporetech/dorado/archive/']
+sources = [{
+    'git_config': {
+        'url': 'https://github.com/nanoporetech',
+        'repo_name': name,
+        'tag': 'v%(version)s',
+        'recursive': True,
+    },
+    'filename': SOURCE_TAR_XZ,
+}]
+
+checksums = [
+    {'dorado-1.4.0.tar.xz': '9675adf0b75e89c9d6b3e9972403fd79b401cabc3f5e08822364e9aa4a30650a'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.31.8'),
+    ('patchelf', '0.18.0'),
+    ('git', '2.45.1'),
+]
+
+dependencies = [
+    ('CUDA', '12.6.0', '', SYSTEM),
+    ('OpenSSL', '3', '', SYSTEM),
+    ('PyTorch', '2.7.1', '-CUDA-%(cudaver)s'),
+    ('HDF5', '1.14.5'),
+    ('zstd', '1.5.6'),
+    ('HTSlib', '1.21'),
+    ('kineto', '0.4.0'),
+    ('libaec', '1.1.3'),
+]
+
+_copts = [
+    "-DCUDA_TOOLKIT_ROOT_DIR=$EBROOTCUDA",
+    "-DCMAKE_CUDA_COMPILER=$EBROOTCUDA/bin/nvcc",
+    '-DOPENSSL_ROOT_DIR=$EBROOTOPENSSL',
+    "-DDORADO_LIBTORCH_DIR=$EBROOTPYTORCH/lib",
+    '-DCMAKE_C_FLAGS="$CFLAGS -pthread"',
+    '-DCMAKE_CXX_FLAGS="$CXXFLAGS -pthread"',
+    '-DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -lcublas"',
+    '-DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS -lcublas"',
+]
+
+configopts = ' '.join(_copts) + ' '
+
+# disable CMake fiddling with RPATH when EasyBuild is configured to use RPATH linking
+configopts += "$(if %(rpath_enabled)s; then "
+configopts += "echo '-DCMAKE_SKIP_INSTALL_RPATH=YES -DCMAKE_SKIP_RPATH=YES'; fi) "
+
+prebuildopts = 'sed -i "s/HTSCODECS\_VERSION\_TEXT/HTSCODECS\_VERSION/" htslib_build/htslib/Makefile '
+prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/Makefile.am '
+prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/htscodecs.c && '
+
+# CUDA libraries that are copied to installdir need to be patched to have an RPATH section
+# when EasyBuild is configured to use RPATH linking (required to pass RPATH sanity check);
+# by default, CMake sets RUNPATH to '$ORIGIN' rather than RPATH (but that's disabled above)
+postinstallcmds = [
+    "if %(rpath_enabled)s; then "
+    "  for lib in $(ls %(installdir)s/lib/lib{cu,nv}*.so*); do "
+    "    echo setting RPATH in $lib;"
+    "    patchelf --force-rpath --set-rpath '$ORIGIN' $lib;"
+    "  done;"
+    "fi",
+]
+
+sanity_check_paths = {
+    'files': ['bin/dorado'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["dorado basecaller --help"]
+
+moduleclass = 'bio'

--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -45,8 +45,8 @@ dependencies = [
 ]
 
 # don't use vendored HTSlib, use provided HTSlib dependency
-preconfigopts = "rm -r ../dorado/dorado/3rdparty/htslib/ && " # Command worked
-preconfigopts = "rm ../dorado/cmake/Htslib.cmake && " # Command worked
+preconfigopts = "rm -r ../dorado/dorado/3rdparty/htslib/ && "
+preconfigopts = "rm ../dorado/cmake/Htslib.cmake && "
 preconfigopts += "sed -i '/Htslib.cmake/d' ../dorado/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/torch_utils/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/read_pipeline/base/CMakeLists.txt && "

--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -47,13 +47,29 @@ dependencies = [
 # don't use vendored HTSlib, use provided HTSlib dependency
 #preconfigopts += "rm -r ../dorado/dorado/3rdparty/htslib/ && "
 preconfigopts = "rm -r ../dorado/dorado/3rdparty/htslib/ && " # Command worked
-preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/CMakeLists.txt && " # Command worked
-preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/dorado/utils/CMakeLists.txt && "
+preconfigopts = "rm ../dorado/cmake/Htslib.cmake && " # Command worked
 preconfigopts += "sed -i '/Htslib.cmake/d' ../dorado/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/torch_utils/CMakeLists.txt && "
+# Gavin changes and additions
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/read_pipeline/base/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/demux/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/resume_loader/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/cli/cli_lib/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/hts_writer/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/alignment/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/polish/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/secondary/CMakeLists.txt && "
+
+#preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/CMakeLists.txt && " # Does not exist
+#preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/dorado/utils/CMakeLists.txt && " # does not exists
+#preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/CMakeLists.txt && " # does not exists
+#preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/utils/CMakeLists.txt && " # does not exists
 # rename link target 'htslib' -> 'hts' only in CMake files, excluding kadayashi's cmake dir
-preconfigopts += r"find ../dorado -type f \( -name CMakeLists.txt -o -name '*.cmake' \) "
-preconfigopts += "-not -path '../dorado/dorado/3rdparty/kadayashi/cmake/*' -print0 | "
-preconfigopts += r"xargs -0 sed -i -E 's/\<htslib\>/hts/g' && "
+
+
+#preconfigopts += r"find ../dorado -type f \( -name CMakeLists.txt -o -name '*.cmake' \) "
+#preconfigopts += "-not -path '../dorado/dorado/3rdparty/kadayashi/cmake/*' -print0 | "
+#preconfigopts += r"xargs -0 sed -i -E 's/\<htslib\>/hts/g' && "
 # keep kadayashi's find_package on 'htslib' and make it return -lhts via its finder
 preconfigopts += r"sed -i -E 's/find_package\(\s*hts\b/find_package(htslib/' "
 preconfigopts += "../dorado/dorado/3rdparty/kadayashi/CMakeLists.txt && "
@@ -77,9 +93,9 @@ configopts = ' '.join(_copts) + ' '
 configopts += "$(if %(rpath_enabled)s; then "
 configopts += "echo '-DCMAKE_SKIP_INSTALL_RPATH=YES -DCMAKE_SKIP_RPATH=YES'; fi) "
 
-prebuildopts = r'sed -i "s/HTSCODECS\_VERSION\_TEXT/HTSCODECS\_VERSION/" htslib_build/htslib/Makefile '
-prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/Makefile.am '
-prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/htscodecs.c && '
+#prebuildopts = r'sed -i "s/HTSCODECS\_VERSION\_TEXT/HTSCODECS\_VERSION/" htslib_build/htslib/Makefile '
+#prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/Makefile.am '
+#prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/htscodecs.c && '
 
 # CUDA libraries that are copied to installdir need to be patched to have an RPATH section
 # when EasyBuild is configured to use RPATH linking (required to pass RPATH sanity check);

--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -45,31 +45,21 @@ dependencies = [
 ]
 
 # don't use vendored HTSlib, use provided HTSlib dependency
-#preconfigopts += "rm -r ../dorado/dorado/3rdparty/htslib/ && "
 preconfigopts = "rm -r ../dorado/dorado/3rdparty/htslib/ && " # Command worked
 preconfigopts = "rm ../dorado/cmake/Htslib.cmake && " # Command worked
 preconfigopts += "sed -i '/Htslib.cmake/d' ../dorado/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/torch_utils/CMakeLists.txt && "
-# Gavin changes and additions
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/read_pipeline/base/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/demux/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/resume_loader/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/cli/cli_lib/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/hts_writer/CMakeLists.txt && "
+preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/hts_utils/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/alignment/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/polish/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/secondary/CMakeLists.txt && "
 
-#preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/CMakeLists.txt && " # Does not exist
-#preconfigopts += "sed -i '/add_dependencies.*htslib_project/d' ../dorado/dorado/utils/CMakeLists.txt && " # does not exists
-#preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/CMakeLists.txt && " # does not exists
-#preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/utils/CMakeLists.txt && " # does not exists
 # rename link target 'htslib' -> 'hts' only in CMake files, excluding kadayashi's cmake dir
-
-
-#preconfigopts += r"find ../dorado -type f \( -name CMakeLists.txt -o -name '*.cmake' \) "
-#preconfigopts += "-not -path '../dorado/dorado/3rdparty/kadayashi/cmake/*' -print0 | "
-#preconfigopts += r"xargs -0 sed -i -E 's/\<htslib\>/hts/g' && "
 # keep kadayashi's find_package on 'htslib' and make it return -lhts via its finder
 preconfigopts += r"sed -i -E 's/find_package\(\s*hts\b/find_package(htslib/' "
 preconfigopts += "../dorado/dorado/3rdparty/kadayashi/CMakeLists.txt && "
@@ -92,10 +82,6 @@ configopts = ' '.join(_copts) + ' '
 # disable CMake fiddling with RPATH when EasyBuild is configured to use RPATH linking
 configopts += "$(if %(rpath_enabled)s; then "
 configopts += "echo '-DCMAKE_SKIP_INSTALL_RPATH=YES -DCMAKE_SKIP_RPATH=YES'; fi) "
-
-#prebuildopts = r'sed -i "s/HTSCODECS\_VERSION\_TEXT/HTSCODECS\_VERSION/" htslib_build/htslib/Makefile '
-#prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/Makefile.am '
-#prebuildopts += 'htslib_build/htslib/htscodecs/htscodecs/htscodecs.c && '
 
 # CUDA libraries that are copied to installdir need to be patched to have an RPATH section
 # when EasyBuild is configured to use RPATH linking (required to pass RPATH sanity check);

--- a/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
+++ b/easyconfigs/d/dorado/dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb
@@ -21,9 +21,11 @@ sources = [{
     },
     'filename': SOURCE_TAR_XZ,
 }]
-
+patches = ['%(name)s-%(version)s_dont_install_external_libraries.patch']
 checksums = [
     {'dorado-1.4.0.tar.xz': '9675adf0b75e89c9d6b3e9972403fd79b401cabc3f5e08822364e9aa4a30650a'},
+    {'dorado-1.4.0_dont_install_external_libraries.patch':
+     'f265b7bb6afcdb7b11f4f543d337c08c2038e98a25df18547f752d7fa4463bd8'},
 ]
 
 builddependencies = [
@@ -47,6 +49,7 @@ dependencies = [
 # don't use vendored HTSlib, use provided HTSlib dependency
 preconfigopts = "rm -r ../dorado/dorado/3rdparty/htslib/ && "
 preconfigopts = "rm ../dorado/cmake/Htslib.cmake && "
+preconfigopts += "sed -i '/Htslib.cmake/d' ../dorado/CMakeLists.txt && "
 preconfigopts += "sed -i '/Htslib.cmake/d' ../dorado/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/torch_utils/CMakeLists.txt && "
 preconfigopts += "sed -i 's/htslib/hts/g' ../dorado/dorado/read_pipeline/base/CMakeLists.txt && "

--- a/easyconfigs/d/dorado/dorado-1.4.0_dont_install_external_libraries.patch
+++ b/easyconfigs/d/dorado/dorado-1.4.0_dont_install_external_libraries.patch
@@ -1,0 +1,11 @@
+--- cmake/InstallRedistLibs.cmake.old	2026-05-15 09:48:46.991115126 +0100
++++ cmake/InstallRedistLibs.cmake	2026-05-15 09:49:56.114081848 +0100
+@@ -15,7 +15,7 @@
+     # bundle the libraries from the cuda toolkit
+     foreach(LIB IN LISTS REQUIRED_CUDA_LIBS)
+         file(GLOB NATIVE_CUDA_LIBS "${CUDAToolkit_TARGET_DIR}/targets/${CMAKE_SYSTEM_PROCESSOR}-linux/lib/${LIB}")
+-        install(FILES ${NATIVE_CUDA_LIBS} DESTINATION lib COMPONENT redist_libs)
++        #install(FILES ${NATIVE_CUDA_LIBS} DESTINATION lib COMPONENT redist_libs)
+     endforeach()
+ 
+     file(GLOB TORCH_DLLS "${TORCH_LIB}/lib/*.so*")


### PR DESCRIPTION
For INC1682088 - `dorado-1.4.0-foss-2024a-CUDA-12.6.0.eb`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

**Note:** Below is the post build message
> CUDA sanity check summary report:
> Number of CUDA files checked: 1
> Number of files missing one or more CUDA Compute Capabilities: 0
> Number of files with device code for more CUDA Compute Capabilities than requested: 1
> (not running with --cuda-sanity-check-error-on-failed-checks, so not considered failures)
> Number of files missing PTX code for the highest configured CUDA Compute Capability: 1
> (not running with --cuda-sanity-check-error-on-failed-checks, so not considered failures)
> You may consider running with --cuda-sanity-check-accept-missing-ptx to accept binaries missing PTX code for the highest configured CUDA Compute Capability.