### PR TITLE
build(Rust_1.88): config from next tc version upstream

### DIFF
--- a/easyconfigs/r/Rust/Rust-1.88.0-GCCcore-13.3.0.eb
+++ b/easyconfigs/r/Rust/Rust-1.88.0-GCCcore-13.3.0.eb
@@ -1,0 +1,31 @@
+name = 'Rust'
+version = '1.88.0'
+
+homepage = 'https://www.rust-lang.org'
+description = """Rust is a systems programming language that runs blazingly fast, prevents segfaults,
+ and guarantees thread safety."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://static.%(namelower)s-lang.org/dist/']
+sources = ['rustc-%(version)s-src.tar.gz']
+patches = ['%(name)s-1.70_sysroot-fix-interpreter.patch']
+checksums = [
+    {'rustc-%(version)s-src.tar.gz': '3a97544434848ae3d193d1d6bc83d6f24cb85c261ad95f955fde47ec64cfcfbe'},
+    {'%(name)s-1.70_sysroot-fix-interpreter.patch': 'aa7a7fe784e463b297c640edfe88b8d96acbee0c173251575cef0426baccc57e'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.31.8'),
+    ('Python', '3.12.3'),
+    ('Ninja', '1.12.1'),
+    ('pkgconf', '2.2.0'),
+    ('patchelf', '0.18.0'),  # only required when RPATH linking is enabled
+]
+dependencies = [
+    ('OpenSSL', '3', '', SYSTEM),
+]
+
+
+moduleclass = 'lang'


### PR DESCRIPTION
For INC1695423 - `easyconfigs/r/Rust/Rust-1.88.0-GCCcore-13.3.0.eb`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
