### PR TITLE
build(Flye): version bump from upstream

### DIFF
--- a/easyconfigs/f/Flye/Flye-2.9.6-GCC-13.3.0.eb
+++ b/easyconfigs/f/Flye/Flye-2.9.6-GCC-13.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'Flye'
+version = "2.9.6"
+
+homepage = 'https://github.com/fenderglass/Flye'
+description = """Flye is a de novo assembler for long and noisy reads, such as those produced by PacBio
+ and Oxford Nanopore Technologies."""
+
+toolchain = {'name': 'GCC', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/fenderglass/Flye/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = []
+dependencies = [('Python', '3.12.3')]
+
+if ARCH == "aarch64":
+    preinstallopts = 'export arm_neon=1 && export aarch64=1 && '
+
+sanity_check_paths = {
+    'files': ['bin/flye'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ['%(namelower)s --help']
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1699093 - `Flye-2.9.6-GCC-13.3.0.eb`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
