### PR TITLE
Kleborate

### DIFF
--- a/easyconfigs/a/AMRFinderPlus/AMRFinderPlus-4.0.23-gompi-2024a.eb
+++ b/easyconfigs/a/AMRFinderPlus/AMRFinderPlus-4.0.23-gompi-2024a.eb
@@ -1,0 +1,68 @@
+easyblock = 'MakeCp'
+
+name = 'AMRFinderPlus'
+version = '4.0.23'
+
+homepage = 'https://github.com/ncbi/amr'
+description = """This software and the accompanying database are designed to find acquired antimicrobial
+ resistance genes and some point mutations in protein or assembled nucleotide sequences."""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+
+sources = [{
+    'filename': 'amrfinderplus-%(version)s.tar.xz',
+    'git_config': {
+        'url': 'https://github.com/ncbi',
+        'repo_name': 'amr',
+        'tag': 'amrfinder_v%(version)s',
+        'recursive': True,   # <-- pull submodules so stx/ has a Makefile
+    },
+}]
+checksums = ['72e16cefb517429716be78034371105f58f7f7e5bf601a04f2841d11de1066bc']
+
+dependencies = [
+    ('BLAST+', '2.16.0'),
+    ('HMMER',  '3.4'),
+    ('cURL',   '8.7.1'),
+]
+
+modextrapaths = {'PATH': ''}
+
+local_binaries = [
+    'amr_report',
+    'amrfinder',
+    'amrfinder_index',
+    'amrfinder_update',
+    'dna_mutation',
+    'fasta2parts',
+    'fasta_check',
+    'fasta_extract',
+    'gff_check',
+]
+
+files_to_copy = [
+    (local_binaries, ''),
+    (['stx/stxtyper', 'stx/stx.prot'], 'stx'),  # stxtyper needed for Kleborate,
+    (['stx/fasta_check', 'stx/fasta_extract'], 'stx'),  # needed for amrfinder test script,
+]
+
+#  amrfinder will only download to the central install location
+#  see https://github.com/ncbi/amr/blob/amrfinder_v4.0.23/amrfinder.cpp
+
+postinstallcmds = [
+    "%(installdir)s/amrfinder -u",
+    "ln -s %(installdir)s/stx/stxtyper %(installdir)s/stxtyper",
+    "ln -s %(installdir)s/stx/stx.prot %(installdir)s/stx.prot",
+]
+
+sanity_check_paths = {
+    'files': local_binaries + ['stx/stxtyper', 'stx/stx.prot'],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    "amrfinder -h",
+    "%(installdir)s/stxtyper --help",
+]
+
+moduleclass = 'bio'

--- a/easyconfigs/e/ECTyper/ECTyper-2.0.0-foss-2024a.eb
+++ b/easyconfigs/e/ECTyper/ECTyper-2.0.0-foss-2024a.eb
@@ -1,0 +1,41 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonPackage'
+
+name = 'ECTyper'
+version = '2.0.0'
+
+homepage = "https://github.com/phac-nml/ecoli_serotyping"
+description = """ECTyper is a standalone versatile serotyping module for Escherichia coli.
+ It supports both fasta (assembled) and fastq (raw reads) file formats.
+"""
+citing = """Bessonov, Kyrylo, Chad Laing, James Robertson, Irene Yong, Kim Ziebell, Victor PJ Gannon,
+ Anil Nichani, Gitanjali Arya, John HE Nash, and Sara Christianson. "ECTyper: in silico Escherichia
+ coli serotype and species prediction from raw and assembled whole-genome sequence data."
+ Microbial genomics 7, no. 12 (2021): 000728.
+ https://www.microbiologyresearch.org/content/journal/mgen/10.1099/mgen.0.000728"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/phac-nml/ecoli_serotyping/archive']
+sources = ['%(version)s.tar.gz']
+checksums = ['3d5ec502880e8f842f3a4b7513dd94706f7176cb37cf71baac5403c5c83058ff']
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('Biopython', '1.84'),  # <=1.85
+    ('BLAST+', '2.16.0'),
+    ('Bowtie2', '2.5.4'),
+    ('seqtk', '1.4'),
+    ('BCFtools', '1.21'),
+    ('SAMtools', '1.21'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/ectyper'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+sanity_check_commands = ['ectyper --help']
+
+moduleclass = 'bio'

--- a/easyconfigs/e/EzClermont/EzClermont-1.0.0-foss-2024a.eb
+++ b/easyconfigs/e/EzClermont/EzClermont-1.0.0-foss-2024a.eb
@@ -1,0 +1,35 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonPackage'
+
+name = 'EzClermont'
+version = '1.0.0'
+
+homepage = "https://github.com/nickp60/EzClermont"
+description = """This is a tool for using the Clermont 2013 PCR typing method for
+ in silico analysis of E. coli whole genomes or assembled contigs.
+"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/nickp60/EzClermont/archive']
+sources = ['%(version)sa.tar.gz']
+checksums = ['89e3fbf77830381e098d1856f3cb82407a01b4992c4fd8a22ae732334883c2a3']
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('Biopython', '1.84'),
+]
+
+preinstallopts = """sed -i 's/^license = "MIT"$/license = {text = "MIT"}/' pyproject.toml && """
+
+options = {'modulename': False}
+
+sanity_check_paths = {
+    'files': ['bin/ezclermont'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+sanity_check_commands = ['ezclermont --help']
+
+moduleclass = 'bio'

--- a/easyconfigs/k/Kleborate/Kleborate-3.2.4-foss-2024a.eb
+++ b/easyconfigs/k/Kleborate/Kleborate-3.2.4-foss-2024a.eb
@@ -1,0 +1,43 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'Kleborate'
+version = '3.2.4'
+
+homepage = "https://kleborate.readthedocs.io/"
+description = """A genomic surveillance framework and genotyping tool for Klebsiella pneumoniae
+ and its related species complex"""
+citing = """Lam, MMC. et al. A genomic surveillance framework and genotyping tool for Klebsiella pneumoniae
+ and its related species complex, Nature Communications (2021).
+ https://www.nature.com/articles/s41467-021-24448-3
+"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('Biopython', '1.84'),  # conflict: docs say 1.85 but reqs >1.83.
+    ('AMRFinderPlus', '4.0.23'),
+    ('Mash', '2.3'),
+    ('Minimap2', '2.30'),
+    ('Kaptive','3.1.0'),
+    #('ectyper', ''), - https://github.com/phac-nml/ecoli_serotyping
+    #('EzClermont', ''), - https://github.com/nickp60/ezclermont
+]
+
+exts_list = [
+    ('dna-features-viewer', '3.1.5', {
+        'sources': ['dna_features_viewer-%(version)s.tar.gz'],
+        'preinstallopts': """sed -i 's/^license = "MIT"$/license = {text = "MIT"}/' pyproject.toml && """,
+        'modulename': 'dna_features_viewer',
+        'checksums': ['4740b018f7c45427054cb1403ff8b11209bcbe4ca9d5b77f28f14ed5ecb144c4'],
+    }),
+    (name, version, {
+        'source_urls': ['https://github.com/klebgenomics/Kleborate/archive'],
+        'sources': ['v%(version)s.tar.gz'],
+        'checksums': ['868fa066638372c065051284a7eb02e071e53cc762c50054faec47c4eca6861f'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easyconfigs/k/Kleborate/Kleborate-3.2.4-foss-2024a.eb
+++ b/easyconfigs/k/Kleborate/Kleborate-3.2.4-foss-2024a.eb
@@ -20,10 +20,10 @@ dependencies = [
     ('Biopython', '1.84'),  # conflict: docs say 1.85 but reqs >1.83.
     ('AMRFinderPlus', '4.0.23'),
     ('Mash', '2.3'),
-    ('Minimap2', '2.30'),
-    ('Kaptive','3.1.0'),
-    #('ectyper', ''), - https://github.com/phac-nml/ecoli_serotyping
-    #('EzClermont', ''), - https://github.com/nickp60/ezclermont
+    ('minimap2', '2.30'),
+    ('Kaptive', '3.1.0'),
+    ('ECTyper', '2.0.0'),
+    ('EzClermont', '1.0.0'),
 ]
 
 exts_list = [
@@ -39,5 +39,14 @@ exts_list = [
         'checksums': ['868fa066638372c065051284a7eb02e071e53cc762c50054faec47c4eca6861f'],
     }),
 ]
+
+sanity_check_paths = {
+    'files': ['bin/kleborate'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ['kleborate --version']
+
+sanity_pip_check = False  # it can't find mash - but it is installed!
 
 moduleclass = 'bio'

--- a/easyconfigs/k/kaptive/Kaptive-3.1.0-foss-2024a.eb
+++ b/easyconfigs/k/kaptive/Kaptive-3.1.0-foss-2024a.eb
@@ -1,0 +1,39 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'Kaptive'
+version = '3.1.0'
+
+homepage = "https://kaptive-web.erc.monash.edu/"
+description = """Kaptive is a tool for bacterial in silico serotyping. It takes one or more
+pre-assembled genomes and for each finds the best matching locus from a reference database."""
+citing = """Stanton TD, Hetland MAK, Löhr IH, Holt KE, Wyres KL. Fast and Accurate in silico
+ Antigen Typing with Kaptive 3 [Internet]. bioRxiv; 2025 [cited 2025 Feb 27]. p. 2025.02.05.636613.
+ Available from: https://www.biorxiv.org/content/10.1101/2025.02.05.636613v1
+"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('matplotlib', '3.9.2'),
+    ('Biopython', '1.84'),  # conflict: docs say 1.85 but reqs >1.83.
+]
+
+exts_list = [
+    ('dna-features-viewer', '3.1.5', {
+        'sources': ['dna_features_viewer-%(version)s.tar.gz'],
+        'preinstallopts': """sed -i 's/^license = "MIT"$/license = {text = "MIT"}/' pyproject.toml && """,
+        'modulename': 'dna_features_viewer',
+        'checksums': ['4740b018f7c45427054cb1403ff8b11209bcbe4ca9d5b77f28f14ed5ecb144c4'],
+    }),
+    (name, version, {
+        'source_urls': ['https://github.com/klebgenomics/Kaptive/archive'],
+        'sources': ['v%(version)s.tar.gz'],
+        #'modulename': '%(namelower)s',
+        'checksums': ['6e5d2bd8bcd7229be3c63b5f8b1d9077351a3f02f181a02b9a6f9af35587ccaf'],
+    }),
+]
+
+moduleclass = 'bio'

--- a/easyconfigs/k/kaptive/Kaptive-3.1.0-foss-2024a.eb
+++ b/easyconfigs/k/kaptive/Kaptive-3.1.0-foss-2024a.eb
@@ -31,7 +31,6 @@ exts_list = [
     (name, version, {
         'source_urls': ['https://github.com/klebgenomics/Kaptive/archive'],
         'sources': ['v%(version)s.tar.gz'],
-        #'modulename': '%(namelower)s',
         'checksums': ['6e5d2bd8bcd7229be3c63b5f8b1d9077351a3f02f181a02b9a6f9af35587ccaf'],
     }),
 ]


### PR DESCRIPTION
For INC1701677:

* `Kleborate-3.2.4-foss-2024a.eb`

Deps:

* `AMRFinderPlus-4.0.23-gompi-2024a.eb` - I have fixed the upstream config here, which did not copy over `stx`. The postinstallcmds are to get the `amrfinder` test script to work. I assume this isn't needed at later usage but don't know for sure.

* `Kaptive-3.1.0-foss-2024a.eb` - new easyconfig
* `ECTyper-2.0.0-foss-2024a.eb` - new easyconfig
* `EzClermont-1.0.0-foss-2024a.eb` - new easyconfig

* Mash will be pulled from upstream. I had to install this to /scratch/ due to ACL issues. It should be fine when building live. 

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
