### PR TITLE
delly

### DIFF
--- a/easyconfigs/d/delly/Delly-2.0.0-GCC-13.3.0.eb
+++ b/easyconfigs/d/delly/Delly-2.0.0-GCC-13.3.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'MakeCp'
+
+name = 'Delly'
+version = '2.0.0'
+
+homepage = 'https://github.com/dellytools/delly/'
+description = """Delly is an integrated structural variant (SV) prediction
+method that can discover, genotype and visualize deletions, tandem duplications,
+inversions and translocations at single-nucleotide resolution in short-read
+massively parallel sequencing data. It uses paired-ends, split-reads and
+read-depth to sensitively and accurately delineate genomic rearrangements
+throughout the genome."""
+
+toolchain = {'name': 'GCC', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'dellytools'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['40c7e80b8bd7652d6e23413278e60aa81b640c44ca250d08475d9a2a135ed5d5']
+
+dependencies = [
+    ('HTSlib', '1.21'),
+    ('Boost', '1.85.0'),
+]
+
+build_cmd = 'make PARALLEL=1 -B src/delly'
+
+files_to_copy = [
+    (['src/delly'], 'bin'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/delly'],
+    'dirs': ['bin']
+}
+
+sanity_check_commands = ['delly']
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1702747 - `Delly-2.0.0-GCC-13.3.0.eb`

Version bump for Delly.
No significant change in build source code between 1.7.3 and 2.0.0

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
