### PR TITLE
jq 1.8.1 against 13.3.0

### DIFF
--- a/easyconfigs/j/jq/jq-1.8.1-GCCcore-13.3.0.eb
+++ b/easyconfigs/j/jq/jq-1.8.1-GCCcore-13.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'jq'
+version = '1.8.1'
+
+homepage = 'https://jqlang.org/'
+description = """jq is a lightweight and flexible command-line JSON processor."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/jqlang/jq/releases/download/jq-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Autotools', '20231222'),
+]
+
+configopts = '--with-oniguruma=builtin'
+
+sanity_check_paths = {
+    'files': ['bin/jq'],
+    'dirs': [],
+}
+
+sanity_check_commands = ['jq --help', 'jq --version']
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1703080 - `jq-1.8.1-GCCcore-13.3.0.eb`

Toolchain drop from upstream.

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
