### PR TITLE
Masurca 4.1.4

### DIFF
--- a/easyconfigs/m/MaSuRCA/MaSuRCA-4.1.4-GCC-12.3.0.eb
+++ b/easyconfigs/m/MaSuRCA/MaSuRCA-4.1.4-GCC-12.3.0.eb
@@ -7,7 +7,7 @@
 # $Id$
 #
 ##
-# Updated 06/26: University of Birmingham 
+# Updated 06/26: University of Birmingham
 # NB: issues with GCC13 - https://github.com/alekseyzimin/masurca/issues/359
 # Rolled in runCA fixes from /pull/18700 + fixed for linting
 

--- a/easyconfigs/m/MaSuRCA/MaSuRCA-4.1.4-GCC-12.3.0.eb
+++ b/easyconfigs/m/MaSuRCA/MaSuRCA-4.1.4-GCC-12.3.0.eb
@@ -1,0 +1,84 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2017 University of Geneva
+# Authors::   Yann Sagon <yann.sagon@unige.ch>
+# License::   MIT/GPL
+# $Id$
+#
+##
+# Updated 06/26: University of Birmingham 
+# NB: issues with GCC13 - https://github.com/alekseyzimin/masurca/issues/359
+# Rolled in runCA fixes from /pull/18700 + fixed for linting
+
+easyblock = 'ConfigureMake'
+
+name = 'MaSuRCA'
+version = '4.1.4'
+
+homepage = 'https://www.genome.umd.edu/masurca.html'
+software_license = 'LicenseGPLv3'
+
+description = '''MaSuRCA is whole genome assembly software. It combines the efficiency of the de Bruijn graph
+ and Overlap-Layout-Consensus (OLC) approaches. MaSuRCA can assemble data sets containing
+ only short reads from Illumina sequencing or a mixture of short reads and long reads
+ (Sanger, 454, Pacbio and Nanopore).'''
+
+toolchain = {'name': 'GCC', 'version': '12.3.0'}
+
+source_urls = ['https://github.com/alekseyzimin/masurca/releases/download/v%(version)s']
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['6112d742bac326917a57d02f71494e5de4c6a67c6bbef8de54f842b9d5873d7d']
+
+builddependencies = [('patchelf', '0.18.0')]
+
+dependencies = [
+    ('libreadline', '8.2'),
+    ('Tcl', '8.6.13'),
+    ('Boost', '1.82.0'),
+    ('zlib', '1.2.13'),
+    ('Perl', '5.36.1'),
+    ('bzip2', '1.0.8'),
+]
+
+buildopts = "install-special"
+start_dir = "global-1"
+
+postinstallcmds = [
+    # fix location of 'bin' in install prefix in runCA and runCA-dedupe scripts
+    # escaping single quotes within single quotes is tricky, so we use $'...' to use ANSI C-like escaping
+    "sed -i $'s|^$bin =.*|$bin = \"$ENV{\'EBROOTMASURCA\'}/bin\";|g' %(installdir)s/bin/runCA",
+    "sed -i $'s|^$bin =.*|$bin = \"$ENV{\'EBROOTMASURCA\'}/bin\";|g' %(installdir)s/bin/runCA-dedupe",
+    # fix hardcoded path in masurca script, just point back to 'bin' subdirectory instead
+    "sed -i 's@../CA8/Linux-amd64/bin@../bin@g' %(installdir)s/bin/masurca",
+    # This four fix the bin path for getBinDirectoryShellCode function used as part as the code to create overlap.sh
+    r"sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/g' %(installdir)s/bin/runCA",
+    r"sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/g' %(installdir)s/bin/runCA-dedupe",
+    r"sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/g' %(installdir)s/bin/runCA-overlapStoreBuild",
+    r"sed -i  's/\$installDir\/\\\$syst-\\\$arch/\\\${EBROOTMASURCA}/g' %(installdir)s/bin/PBcR",
+    # This four fix the bin path for getBinDirectory function
+    "sed -i $'s|my $path = \"$installDir/$syst-$arch/bin\"|my $path = \"$ENV{\\'EBROOTMASURCA\\'}/bin\"|g' "
+    "%(installdir)s/bin/runCA",
+    "sed -i $'s|my $path = \"$installDir/$syst-$arch/bin\"|my $path = \"$ENV{\\'EBROOTMASURCA\\'}/bin\"|g' "
+    "%(installdir)s/bin/runCA-dedupe",
+    "sed -i $'s|return(\"$installDir/$syst-$arch/bin\"|return(\"$ENV{\\'EBROOTMASURCA\\'}/bin\"|g' "
+    "%(installdir)s/bin/runCA-overlapStoreBuild",
+    "sed -i $'s|my $path = \"$installDir/$syst-$arch/bin\"|my $path = \"$ENV{\\'EBROOTMASURCA\\'}/bin\"|g' "
+    "%(installdir)s/bin/PBcR",
+    # commands to install built-in version of Flye
+    "cd ../Flye && make && cp -a ../Flye %(installdir)s",
+    # fix missing RPATH
+    "patchelf --force-rpath --set-rpath '$ORIGIN' %(installdir)s/bin/falcon_sense",
+]
+
+sanity_check_paths = {
+    'files': ['bin/masurca', 'Flye/bin/flye'],
+    'dirs': ['include', 'lib'],
+}
+
+sanity_check_commands = [
+    "masurca --help",
+    "runCA --help",
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1704080 - `MaSuRCA-4.1.4-GCC-12.3.0.eb`

I've gone for 2023a as there are some GCC13 issues with some of the submodule code (https://github.com/alekseyzimin/masurca/issues/359)

I've interpolated the additional fixes from /pull/18700 and fixed them for the linter (it didn't like the escaping)

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
