### PR TITLE
CST 2026 SP4

### DIFF
--- a/easyconfigs/c/CST-Studio-Suite/CST-Studio-Suite-2026.SP4-GCCcore-13.3.0-Java-17.eb
+++ b/easyconfigs/c/CST-Studio-Suite/CST-Studio-Suite-2026.SP4-GCCcore-13.3.0-Java-17.eb
@@ -1,0 +1,43 @@
+easyblock = 'EB_CST'
+
+name = 'CST-Studio-Suite'
+version = '2026.SP4'
+versionsuffix = '-Java-17'
+
+homepage = 'https://www.3ds.com/products-services/simulia/products/cst-studio-suite/'
+description = """CST Studio Suite is a high-performance 3D EM analysis software package for designing, analyzing and
+ optimizing electromagnetic (EM) components and systems."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+sources = [
+    'CST_S2_2026/CST_S2_2026.CST_S2_2026.SIMULIA_CST_Studio_Suite.Linux64.tar',
+    'CST_S2_2026/CST_S2_2026_SP4.SPK_SIMULIA_CST_Studio_Suite.Linux64.tar.gz',
+]
+checksums = [
+    {'CST_S2_2026.CST_S2_2026.SIMULIA_CST_Studio_Suite.Linux64.tar':
+     'cebb1366154b7100b6c6b709b1d1ff6f6a7f2f2d0a641e59958ad1b92f37e2d5'},
+    {'CST_S2_2026_SP4.SPK_SIMULIA_CST_Studio_Suite.Linux64.tar.gz':
+     '84560837811b40265eff640764ba503d5a5ca9a66526a155f64341e22dfcf0f8'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+dependencies = [
+    ('Java', '17', '', SYSTEM),
+    ('motif', '2.3.8'),
+    ('Xvfb', '21.1.14'),
+]
+
+license_server = 'eee-cst-ce.bham.ac.uk'
+license_server_port = '27004'
+sp_level = '%(version_minor)s'
+extract_sources = True
+
+modextravars = {
+    'CST_FORCE_SOFTWARE_RENDERER': '1',
+    'CST_FORCE_X11_PRELOAD': '1'
+}
+
+moduleclass = 'cae'


### PR DESCRIPTION
For INC1697363 - `CST-Studio-Suite-2026.SP4-GCCcore-13.3.0-Java-17.eb`

Changes from `2026.SP2`:
- Remove CST Support's previously provided REGSRV fix.
- Add `CST_FORCE_X11_PRELOAD` env var.


* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
