### PR TITLE
ANSYS Rocky 2026R1

### DIFF
--- a/easyconfigs/a/ANSYS_Rocky/ANSYS_Rocky-2026R1.eb
+++ b/easyconfigs/a/ANSYS_Rocky/ANSYS_Rocky-2026R1.eb
@@ -1,0 +1,47 @@
+easyblock = 'CmdCp'
+
+name = 'ANSYS_Rocky'
+version = '2026R1'
+local_ansysver = 'v261'
+
+homepage = "https://www.ansys.com/en-gb/products/fluids/ansys-rocky"
+description = """Ansys Rocky is the industry-leading discrete element method (DEM)
+ software that quickly and accurately simulates particle flow behavior."""
+
+toolchain = SYSTEM
+
+download_instructions = """Login and download from https://download.ansys.com/currentReleases.
+Navigate to the "AddOn Packages" section and retrieve the "Main Package" download.
+"""
+
+sources = ["ROCKY_%(version)s_LINX64.tgz"]
+checksums = ['6d5b15c8ca4b93c401299b498f046d959c5b48f1073c6feda1472b98ab8c781a']
+
+dependencies = [
+    ('alsa-lib', '1.2.10'),
+    ('ANSYS', '2026R1'),
+    ('CUDA', '12.6.0'),  # Using CUDA version already available on BlueBEAR
+]
+
+cmds_map = [(
+    '.*',
+    "./INSTALL -silent -nochecks -install_dir %(installdir)s"
+)]
+
+skipsteps = ['install']  # the install step deletes the directory created by the above command
+files_to_copy = []
+
+postinstallcmds = [
+    "chmod +x %%(installdir)s/%s/rocky/Rocky*" % local_ansysver,
+]
+
+# Binaries are installed to the "rocky" subdirectory so add that to the PATH
+modextrapaths = {'PATH': '%s/rocky' % local_ansysver}
+
+sanity_check_paths = {
+    'files': ['%s/rocky/bin/%s' % (local_ansysver, x) for x in ['Rocky', 'RockySolver']]
+    + ['%s/rocky/bin/Rocky' % local_ansysver],
+    'dirs': ['%s/rocky/bin/%s' % (local_ansysver, x) for x in ['lib', 'share']],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1706016 - `ANSYS_Rocky-2026R1.eb`

Minor changes from 2025R2 easyconf:
- Version bump.
- ANSYS dependency version bump to match.

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
