### PR TITLE
restore chmod command

### DIFF
--- a/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
+++ b/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
@@ -38,7 +38,7 @@ local_monopogen_path = "%(installdir)s/lib/python%(pyshortver)s/site-packages/Mo
 postinstallcmds = [
     "mkdir -p %(installdir)s/bin",
     f"ln -s {local_monopogen_path} %(installdir)s/bin/Monopogen.py",
-    f"chmod +x {local_monopogen_path}"
+    f"chmod +x {local_monopogen_path}",
     f"""sed -i "s|'--app-path', required=True|'--app-path', default='%(installdir)s/apps'|" {local_monopogen_path}""",
     "cp -r apps %(installdir)s/.",
 ]

--- a/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
+++ b/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
@@ -38,6 +38,7 @@ local_monopogen_path = "%(installdir)s/lib/python%(pyshortver)s/site-packages/Mo
 postinstallcmds = [
     "mkdir -p %(installdir)s/bin",
     f"ln -s {local_monopogen_path} %(installdir)s/bin/Monopogen.py",
+    f"chmod +x {local_monopogen_path}"
     f"""sed -i "s|'--app-path', required=True|'--app-path', default='%(installdir)s/apps'|" {local_monopogen_path}""",
     "cp -r apps %(installdir)s/.",
 ]


### PR DESCRIPTION
Restore `chmod +x` that was removed in #846. It was really needed. Has already been built live.