### PR TITLE
[REBUILD] monopogen

### DIFF
--- a/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
+++ b/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
@@ -36,10 +36,6 @@ fix_python_shebang_for = ['lib/python%(pyshortver)s/site-packages/Monopogen.py']
 
 local_monopogen_path = "%(installdir)s/lib/python%(pyshortver)s/site-packages/Monopogen.py"
 
-local_monopogen_apps = [
-    'bcftools', 'bgzip', 'gzip', 'java', 'samtools', 'tabix', 'vcftools'
-]
-
 postinstallcmds = [
     "mkdir -p %(installdir)s/bin",
     f"ln -s {local_monopogen_path} %(installdir)s/bin/Monopogen.py",

--- a/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
+++ b/easyconfigs/m/Monopogen/Monopogen-1.6.0-foss-2024a.eb
@@ -35,12 +35,18 @@ local_monopogen_scripts = [
 fix_python_shebang_for = ['lib/python%(pyshortver)s/site-packages/Monopogen.py']
 
 local_monopogen_path = "%(installdir)s/lib/python%(pyshortver)s/site-packages/Monopogen.py"
+
+local_monopogen_apps = [
+    'bcftools', 'bgzip', 'gzip', 'java', 'samtools', 'tabix', 'vcftools'
+]
+
 postinstallcmds = [
     "mkdir -p %(installdir)s/bin",
     f"ln -s {local_monopogen_path} %(installdir)s/bin/Monopogen.py",
     f"chmod +x {local_monopogen_path}",
     f"""sed -i "s|'--app-path', required=True|'--app-path', default='%(installdir)s/apps'|" {local_monopogen_path}""",
     "cp -r apps %(installdir)s/.",
+    'find %(installdir)s/apps -maxdepth 1 -type f ! -name "*.jar" ! -name "*.so*" -exec chmod a+x {} \\;',
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
For INC1710639

Reason:
I initially didn't include the bundled apps in /apps/ because they were old. I assumed that paths passed to `-a` would find externally provided modules e.g. samtools. However, this is not the case. We can clearly see in /src/Monopogen.py#L326 that it will only ever find its own samtools and it frankly isn't worth patching **_intended_** behaviour (these versions are the limit of what Monopogen can support).

This PR simply adds +x to the executables in that directory.

**Command:**
`eb Monopogen-1.6.0-foss-2024a.eb -Tr --rebuild --force`

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake

2023a and above:
* [x] EL8-sapphire
