### PR TITLE
Mmlong2 :white_check_mark:

### DIFF
--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -29,13 +29,13 @@ extract_sources = True
 
 channels = ['conda-forge', 'bioconda']
 requirements = ' '.join([
-    'snakemake=9.12.0', 
+    'snakemake=9.12.0',
     'singularity=3.8.6',
     'zenodo_get=1.6.1',
     'pv=1.6.6',
     'pigz=2.8',
     'tar=1.35',
-    'rsync=3.3.0',  
+    'rsync=3.3.0',
     'yq=3.4.3',
     'ncbi-amrfinderplus=4.0.23',
     '%(name)s=%(version)s',
@@ -45,36 +45,36 @@ _zenodo_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
 _BEAR_APPS_DATA_VAR = 'EBMMLONG2DATA121'  # suggest versioning the data collection
-_BEAR_APPS_DATA_PATH =  '$(printf "%s" "$BEAR_APPS_DATA/m/%(name)s/%(version)s")'
+_BEAR_APPS_DATA_PATH = '$(printf "%s" "$BEAR_APPS_DATA/m/%(name)s/%(version)s")'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components
     f'mkdir -p {_test_prefix}',  # prepare test_run location
-    # prepare singularity community edition directories 
+    # prepare singularity community edition directories
     f'sed -i "301,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # a workaround for setting permission on lite
     f' cp -ar {_test_prefix}/sing-%(name)s-lite|" {_installed_bin}/mmlong2',
     f'sed -i "302,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # a workaround for setting permission on proc
     f' cp -ar {_test_prefix}/sing-%(name)s-proc|" {_installed_bin}/mmlong2',
     f'cd {_test_prefix} && {_installed_bin}/zenodo_get -r {_zenodo_src} || true',  # get data for the first run
-    f"sed -i 's|/path/to|${_BEAR_APPS_DATA_VAR}|g' {_installed_bin}/mmlong2-proc-config.yaml",  # databases 
+    f"sed -i 's|/path/to|${_BEAR_APPS_DATA_VAR}|g' {_installed_bin}/mmlong2-proc-config.yaml",  # databases
     r"sed -i 's|\(config\[\"db_\)\([^]]*\]\)|os.path.expandvars(\1\2\)|g'"
-    f" {_installed_bin}/mmlong2-proc.smk",  # interpret expanded environment vars from smk configs for db 
-    r"sed -i '40,44s|\(db_.*=\)\(.*\)|eval \"\1\2\"|'" f" {_installed_bin}/mmlong2", 
+    f" {_installed_bin}/mmlong2-proc.smk",  # interpret expanded environment vars from smk configs for db
+    r"sed -i '40,44s|\(db_.*=\)\(.*\)|eval \"\1\2\"|'" f" {_installed_bin}/mmlong2",
     f'export {_BEAR_APPS_DATA_VAR}="{_BEAR_APPS_DATA_PATH}";'
     f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2'
     f' --install_databases'  # database auto install and versioning and persist in config, exits after install
     f' --database_dir {_BEAR_APPS_DATA_PATH}'  # database destdir if uncommented checks install and exists early
-    f' --database_gtdb ${_BEAR_APPS_DATA_VAR}/gtdb/database_dir'  # to the gtdb location 
-    f' --database_bakta ${_BEAR_APPS_DATA_VAR}/bakta/database_dir'  # to the bakta location 
-    f' --database_rrna ${_BEAR_APPS_DATA_VAR}/rrna/database_file.udb'  # to the rrna location 
-    f' --database_gunc ${_BEAR_APPS_DATA_VAR}/gunc/database_file.dmnd'  # to the gunc location 
+    f' --database_gtdb ${_BEAR_APPS_DATA_VAR}/gtdb/database_dir'  # to the gtdb location
+    f' --database_bakta ${_BEAR_APPS_DATA_VAR}/bakta/database_dir'  # to the bakta location
+    f' --database_rrna ${_BEAR_APPS_DATA_VAR}/rrna/database_file.udb'  # to the rrna location
+    f' --database_gunc ${_BEAR_APPS_DATA_VAR}/gunc/database_file.dmnd'  # to the gunc location
     # create empty directory inplace so the install of that database does not fail. URL is invalid as of 12/08/26
     f' $(mkdir -p {_BEAR_APPS_DATA_PATH}/metabuli/database_dir) '
-    f' --database_metabuli ${_BEAR_APPS_DATA_VAR}/metabuli/database_dir',  # to the metabuli location 
-    f'export {_BEAR_APPS_DATA_VAR}="{_BEAR_APPS_DATA_PATH}";' # test-run stage + container install
-    f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2' 
+    f' --database_metabuli ${_BEAR_APPS_DATA_VAR}/metabuli/database_dir',  # to the metabuli location
+    f'export {_BEAR_APPS_DATA_VAR}="{_BEAR_APPS_DATA_PATH}";'  # test-run stage + container install
+    f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2'
     f' -np {_test_prefix}/mmlong2_np.fastq.gz'
-    f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',  
+    f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',
     # first run does two things: 1. tests install. 2. fetches containers into install_dir/bin
 ]
 sanity_check_paths = {

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -45,7 +45,7 @@ _zenodo_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
 _BEAR_APPS_DATA_VAR = 'EBMMLONG2DATA121'  # suggest versioning the data collection
-_BEAR_APPS_DATA_PATH =  '$(eval $BEAR_APPS_DATA/m/%(name)s/%(version)s)'
+_BEAR_APPS_DATA_PATH =  '$(eval "echo $BEAR_APPS_DATA/m/%(name)s/%(version)s")'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -35,53 +35,34 @@ requirements = ' '.join([
     'pv=1.6.6',
     'pigz=2.8',
     'tar=1.35',
-#    'rsync=3.4.1',  # singularityCE requirements resolution conflict, use system's
     'rsync=3.3.0',  
     'yq=3.4.3',
     'ncbi-amrfinderplus=4.0.23',
     '%(name)s=%(version)s',
 ])
-'''
-conda create --prefix mmlong2 -c conda-forge -c bioconda
 
-snakemake=9.12.0 singularity=3.8.6 zenodo_get=1.6.1 pv=1.6.6
-pigz=2.8 tar=1.35 rsync=3.4.1 yq=3.4.3 ncbi-amrfinderplus=4.0.23 -y
-
-conda activate ./mmlong2 || source activate ./mmlong2
-git clone https://github.com/Serka-M/mmlong2 mmlong2/repo
-cp -r mmlong2/repo/src/* mmlong2/bin
-chmod +x mmlong2/bin/mmlong2
-mmlong2 -h
-'''
-
-_zenodo_apptainer_src = '12168493'  # '17012181'
-# local_checksum = '4c7efcca37c5f5ffb1f1c227427d70a44972fe8eb50860e5e11b9b9f5af71eb0'
+_zenodo_apptainer_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
+_BEAR_APPS_DATA_VAR = 'EBROOTMMLONG2DATA'
+_BEAR_APPS_DATA_PATH = '$HOME/vidri/data/mmlong2'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components
     f'mkdir -p {_test_prefix}',  # prepare test_run location
     # prepare singularity community edition directories 
-    f'sed -i "301,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # horrible line as a workaround for setting permission on lite
+    f'sed -i "301,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # a workaround for setting permission on lite
     f' cp -ar {_test_prefix}/sing-%(name)s-lite|" {_installed_bin}/mmlong2',
-    f'sed -i "302,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # horrible line as a workaround for setting permission on proc
+    f'sed -i "302,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # a workaround for setting permission on proc
     f' cp -ar {_test_prefix}/sing-%(name)s-proc|" {_installed_bin}/mmlong2',
     f'cd {_test_prefix} && {_installed_bin}/zenodo_get -r 12168493 || true',  # get data for the first run
-    f'PATH={_installed_bin}:$PATH mmlong2 -np {_test_prefix}/mmlong2_np.fastq.gz'
+    f"sed -i 's|/path/to|${_BEAR_APPS_DATA_VAR}|g' {_installed_bin}/mmlong2-proc-config.yaml",  # databases 
+    f'PATH={_installed_bin}:$PATH {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH} mmlong2'
+    f' --database_gtdb ${_BEAR_APPS_DATA_VAR}'  # wrapper to the data location 
+    f' -np {_test_prefix}/mmlong2_np.fastq.gz'
     f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',  
     # first run does two things: 1. tests install. 2. fetches containers into install_dir/bin
 ]
-""" Dails on database requirement which presumably can be installed into apps-data with:  mmlong2 --install_databases
-[Thu Aug  6 23:00:38 2026]
-Finished jobid: 0 (Rule: Finalise)
-27 of 27 steps (100%) done
-MAG recovery with pipeline version 1.2.1 completed at 2026/08/06 23:00:38
-Thank you for using mmlong2-lite
-ERROR: Provided rRNA database not found at /path/to/rrna/database_file.udb
-Database can be installed by running the workflow with --install_databases option
-"""
-
 sanity_check_paths = {
     'files': ['bin/%(name)s', 'bin/sing-%(name)s-{lite,proc}'],
     'dirs': ['include', 'lib'],
@@ -90,5 +71,6 @@ sanity_check_paths = {
 sanity_check_commands = [
     "%(name)s -h",
 ]
+modextravars = [f'{_BEAR_APPS_DATA_VAR}': f'{_BEAR_APPS_DATA_PATH}']
 
 moduleclass = 'bio'

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -41,11 +41,11 @@ requirements = ' '.join([
     '%(name)s=%(version)s',
 ])
 
-_zenodo_apptainer_src = '12168493'
+_zenodo_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
-_BEAR_APPS_DATA_VAR = 'EBROOTMMLONG2DATA'
-_BEAR_APPS_DATA_PATH = '$HOME/vidri/data/mmlong2'
+_BEAR_APPS_DATA_VAR = 'EBMMLONG2DATA121'  # suggest versioning the data collection
+_BEAR_APPS_DATA_PATH = '/rds/projects/m/......'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components
@@ -55,22 +55,31 @@ postinstallcmds = [
     f' cp -ar {_test_prefix}/sing-%(name)s-lite|" {_installed_bin}/mmlong2',
     f'sed -i "302,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # a workaround for setting permission on proc
     f' cp -ar {_test_prefix}/sing-%(name)s-proc|" {_installed_bin}/mmlong2',
-    f'cd {_test_prefix} && {_installed_bin}/zenodo_get -r 12168493 || true',  # get data for the first run
+    f'cd {_test_prefix} && {_installed_bin}/zenodo_get -r {_zenodo_src} || true',  # get data for the first run
     f"sed -i 's|/path/to|${_BEAR_APPS_DATA_VAR}|g' {_installed_bin}/mmlong2-proc-config.yaml",  # databases 
-    f'PATH={_installed_bin}:$PATH {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH} mmlong2'
-    f' --database_gtdb ${_BEAR_APPS_DATA_VAR}'  # wrapper to the data location 
+    f'export {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH};'
+    f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2'
+#    f' --install_databases'  # database auto install and versioning and persist in config, exits after install
+#    f' --database_dir {_BEAR_APPS_DATA_PATH}'  # database destdir if uncommented checks install and exists early
+    f' --database_gtdb ${_BEAR_APPS_DATA_VAR}/gtdb/database_dir'  # to the gtdb location 
+    f' --database_bakta ${_BEAR_APPS_DATA_VAR}/bakta/database_dir'  # to the bakta location 
+    f' --database_rrna ${_BEAR_APPS_DATA_VAR}/rrna/database_file.udb'  # to the rrna location 
+    f' --database_gunc ${_BEAR_APPS_DATA_VAR}/gunc/database_file.dmnd'  # to the gunc location 
+    # create empty directory inplace so the install of that database does not fail. URL is invalid as of 12/08/26
+    f' $(mkdir -p {_BEAR_APPS_DATA_PATH}/metabuli/database_dir) '
+    f' --database_metabuli ${_BEAR_APPS_DATA_VAR}/metabuli/database_dir'  # to the metabuli location 
     f' -np {_test_prefix}/mmlong2_np.fastq.gz'
     f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',  
     # first run does two things: 1. tests install. 2. fetches containers into install_dir/bin
 ]
 sanity_check_paths = {
-    'files': ['bin/%(name)s', 'bin/sing-%(name)s-{lite,proc}'],
+    'files': ['bin/%(name)s', 'bin/sing-%(name)s-lite', 'bin/sing-%(name)s-proc'],
     'dirs': ['include', 'lib'],
 }
 
 sanity_check_commands = [
     "%(name)s -h",
 ]
-modextravars = [f'{_BEAR_APPS_DATA_VAR}': f'{_BEAR_APPS_DATA_PATH}']
+modextravars = {f'{_BEAR_APPS_DATA_VAR}': f'{_BEAR_APPS_DATA_PATH}'}
 
 moduleclass = 'bio'

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -45,7 +45,7 @@ _zenodo_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
 _BEAR_APPS_DATA_VAR = 'EBMMLONG2DATA121'  # suggest versioning the data collection
-_BEAR_APPS_DATA_PATH = '/rds/projects/m/......'
+_BEAR_APPS_DATA_PATH = '/rds/projects/m/...'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components
@@ -59,15 +59,17 @@ postinstallcmds = [
     f"sed -i 's|/path/to|${_BEAR_APPS_DATA_VAR}|g' {_installed_bin}/mmlong2-proc-config.yaml",  # databases 
     f'export {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH};'
     f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2'
-#    f' --install_databases'  # database auto install and versioning and persist in config, exits after install
-#    f' --database_dir {_BEAR_APPS_DATA_PATH}'  # database destdir if uncommented checks install and exists early
+    f' --install_databases'  # database auto install and versioning and persist in config, exits after install
+    f' --database_dir {_BEAR_APPS_DATA_PATH}'  # database destdir if uncommented checks install and exists early
     f' --database_gtdb ${_BEAR_APPS_DATA_VAR}/gtdb/database_dir'  # to the gtdb location 
     f' --database_bakta ${_BEAR_APPS_DATA_VAR}/bakta/database_dir'  # to the bakta location 
     f' --database_rrna ${_BEAR_APPS_DATA_VAR}/rrna/database_file.udb'  # to the rrna location 
     f' --database_gunc ${_BEAR_APPS_DATA_VAR}/gunc/database_file.dmnd'  # to the gunc location 
     # create empty directory inplace so the install of that database does not fail. URL is invalid as of 12/08/26
     f' $(mkdir -p {_BEAR_APPS_DATA_PATH}/metabuli/database_dir) '
-    f' --database_metabuli ${_BEAR_APPS_DATA_VAR}/metabuli/database_dir'  # to the metabuli location 
+    f' --database_metabuli ${_BEAR_APPS_DATA_VAR}/metabuli/database_dir',  # to the metabuli location 
+    f'export {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH};' # test-run stage + container install
+    f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2' 
     f' -np {_test_prefix}/mmlong2_np.fastq.gz'
     f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',  
     # first run does two things: 1. tests install. 2. fetches containers into install_dir/bin

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -45,7 +45,7 @@ _zenodo_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
 _BEAR_APPS_DATA_VAR = 'EBMMLONG2DATA121'  # suggest versioning the data collection
-_BEAR_APPS_DATA_PATH = '/rds/projects/m/...'
+_BEAR_APPS_DATA_PATH =  '$(eval $BEAR_APPS_DATA/m/%(name)s/%(version)s)'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components
@@ -75,8 +75,8 @@ postinstallcmds = [
     # first run does two things: 1. tests install. 2. fetches containers into install_dir/bin
 ]
 sanity_check_paths = {
-    'files': ['bin/%(name)s', 'bin/sing-%(name)s-lite', 'bin/sing-%(name)s-proc'],
-    'dirs': ['include', 'lib'],
+    'files': ['bin/%(name)s'],
+    'dirs': ['include', 'lib', 'bin/sing-%(name)s-lite', 'bin/sing-%(name)s-proc'],
 }
 
 sanity_check_commands = [

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -45,7 +45,7 @@ _zenodo_src = '12168493'
 _test_prefix = '/scratch/$USER/sing'
 _installed_bin = '%(install_dir)s/bin'
 _BEAR_APPS_DATA_VAR = 'EBMMLONG2DATA121'  # suggest versioning the data collection
-_BEAR_APPS_DATA_PATH =  '$(eval "echo $BEAR_APPS_DATA/m/%(name)s/%(version)s")'
+_BEAR_APPS_DATA_PATH =  '$(printf "%s" "$BEAR_APPS_DATA/m/%(name)s/%(version)s")'
 
 postinstallcmds = [
     # The following commands are for the purpose to setup singularity instances as final installation components
@@ -57,7 +57,10 @@ postinstallcmds = [
     f' cp -ar {_test_prefix}/sing-%(name)s-proc|" {_installed_bin}/mmlong2',
     f'cd {_test_prefix} && {_installed_bin}/zenodo_get -r {_zenodo_src} || true',  # get data for the first run
     f"sed -i 's|/path/to|${_BEAR_APPS_DATA_VAR}|g' {_installed_bin}/mmlong2-proc-config.yaml",  # databases 
-    f'export {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH};'
+    r"sed -i 's|\(config\[\"db_\)\([^]]*\]\)|os.path.expandvars(\1\2\)|g'"
+    f" {_installed_bin}/mmlong2-proc.smk",  # interpret expanded environment vars from smk configs for db 
+    r"sed -i '40,44s|\(db_.*=\)\(.*\)|eval \"\1\2\"|'" f" {_installed_bin}/mmlong2", 
+    f'export {_BEAR_APPS_DATA_VAR}="{_BEAR_APPS_DATA_PATH}";'
     f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2'
     f' --install_databases'  # database auto install and versioning and persist in config, exits after install
     f' --database_dir {_BEAR_APPS_DATA_PATH}'  # database destdir if uncommented checks install and exists early
@@ -68,7 +71,7 @@ postinstallcmds = [
     # create empty directory inplace so the install of that database does not fail. URL is invalid as of 12/08/26
     f' $(mkdir -p {_BEAR_APPS_DATA_PATH}/metabuli/database_dir) '
     f' --database_metabuli ${_BEAR_APPS_DATA_VAR}/metabuli/database_dir',  # to the metabuli location 
-    f'export {_BEAR_APPS_DATA_VAR}={_BEAR_APPS_DATA_PATH};' # test-run stage + container install
+    f'export {_BEAR_APPS_DATA_VAR}="{_BEAR_APPS_DATA_PATH}";' # test-run stage + container install
     f' cd {_test_prefix}; PATH={_installed_bin}:$PATH  mmlong2' 
     f' -np {_test_prefix}/mmlong2_np.fastq.gz'
     f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',  
@@ -82,6 +85,7 @@ sanity_check_paths = {
 sanity_check_commands = [
     "%(name)s -h",
 ]
-modextravars = {f'{_BEAR_APPS_DATA_VAR}': f'{_BEAR_APPS_DATA_PATH}'}
+modextravars = {f'{_BEAR_APPS_DATA_VAR}': f'{_BEAR_APPS_DATA_PATH}',
+                f'SINGULARITYENV_{_BEAR_APPS_DATA_VAR}': f'{_BEAR_APPS_DATA_PATH}'}
 
 moduleclass = 'bio'

--- a/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
+++ b/easyconfigs/m/mmlong2/mmlong2-1.2.1.eb
@@ -1,0 +1,94 @@
+easyblock = 'Conda'
+
+name = 'mmlong2'
+version = '1.2.1'
+
+homepage = 'https://github.com/Serka-M/mmlong2'
+description = """Genome-centric long-read metagenomics workflow for automated recovery and analysis of
+ prokaryotic genomes with Nanopore or PacBio HiFi sequencing data. The mmlong2 workflow is a continuation
+ of mmlong.
+"""
+
+github_account = 'Serka-M'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['562e598a5a9c62b98ecb9799c9393b322f5e7f4e857c668a62db83c098afa768']
+
+citing = """
+Sereika, M., Mussig, A.J., Jiang, C. et al.
+ Genome-resolved long-read sequencing expands known microbial
+ diversity across terrestrial habitats. Nat Microbiol (2025).
+ https://doi.org/10.1038/s41564-025-02062-z
+"""
+
+toolchain = SYSTEM
+
+dependencies = [('Miniforge3', '25.3.0-3')]
+
+extract_sources = True
+
+channels = ['conda-forge', 'bioconda']
+requirements = ' '.join([
+    'snakemake=9.12.0', 
+    'singularity=3.8.6',
+    'zenodo_get=1.6.1',
+    'pv=1.6.6',
+    'pigz=2.8',
+    'tar=1.35',
+#    'rsync=3.4.1',  # singularityCE requirements resolution conflict, use system's
+    'rsync=3.3.0',  
+    'yq=3.4.3',
+    'ncbi-amrfinderplus=4.0.23',
+    '%(name)s=%(version)s',
+])
+'''
+conda create --prefix mmlong2 -c conda-forge -c bioconda
+
+snakemake=9.12.0 singularity=3.8.6 zenodo_get=1.6.1 pv=1.6.6
+pigz=2.8 tar=1.35 rsync=3.4.1 yq=3.4.3 ncbi-amrfinderplus=4.0.23 -y
+
+conda activate ./mmlong2 || source activate ./mmlong2
+git clone https://github.com/Serka-M/mmlong2 mmlong2/repo
+cp -r mmlong2/repo/src/* mmlong2/bin
+chmod +x mmlong2/bin/mmlong2
+mmlong2 -h
+'''
+
+_zenodo_apptainer_src = '12168493'  # '17012181'
+# local_checksum = '4c7efcca37c5f5ffb1f1c227427d70a44972fe8eb50860e5e11b9b9f5af71eb0'
+_test_prefix = '/scratch/$USER/sing'
+_installed_bin = '%(install_dir)s/bin'
+
+postinstallcmds = [
+    # The following commands are for the purpose to setup singularity instances as final installation components
+    f'mkdir -p {_test_prefix}',  # prepare test_run location
+    # prepare singularity community edition directories 
+    f'sed -i "301,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # horrible line as a workaround for setting permission on lite
+    f' cp -ar {_test_prefix}/sing-%(name)s-lite|" {_installed_bin}/mmlong2',
+    f'sed -i "302,0s|tar xf - -C|tar -xpf - -C {_test_prefix};'  # horrible line as a workaround for setting permission on proc
+    f' cp -ar {_test_prefix}/sing-%(name)s-proc|" {_installed_bin}/mmlong2',
+    f'cd {_test_prefix} && {_installed_bin}/zenodo_get -r 12168493 || true',  # get data for the first run
+    f'PATH={_installed_bin}:$PATH mmlong2 -np {_test_prefix}/mmlong2_np.fastq.gz'
+    f' -o {_test_prefix}/mmlong2_testrun_np -p 60 -run binning -myl',  
+    # first run does two things: 1. tests install. 2. fetches containers into install_dir/bin
+]
+""" Dails on database requirement which presumably can be installed into apps-data with:  mmlong2 --install_databases
+[Thu Aug  6 23:00:38 2026]
+Finished jobid: 0 (Rule: Finalise)
+27 of 27 steps (100%) done
+MAG recovery with pipeline version 1.2.1 completed at 2026/08/06 23:00:38
+Thank you for using mmlong2-lite
+ERROR: Provided rRNA database not found at /path/to/rrna/database_file.udb
+Database can be installed by running the workflow with --install_databases option
+"""
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s', 'bin/sing-%(name)s-{lite,proc}'],
+    'dirs': ['include', 'lib'],
+}
+
+sanity_check_commands = [
+    "%(name)s -h",
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1718957 - `mmlong2-1.2.1.eb`

Easyconfig trigger database installation if not present in prefix which evaluates from environment `BEAR_APPS_DATA`. This variable should be set to point to where the standard reference datasets would be stored, if not already present on local filesystem software would download authomatically.
Metabuli gtdb was not available at the time so the postcommand line contains disabling the logic for its download instructions.  

* [ ] Assigned to reviewer

Default:
* [ ] EL8-icelake

2023a and above:
* [ ] EL8-sapphire
